### PR TITLE
feat: fix load file from url

### DIFF
--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -120,7 +120,7 @@ const Content = () => {
             // builds the path from the url checking if the nodes exist
             const path = [encodeID(drive.state.global.id)];
             let currentNodes = drive.state.global.nodes.filter(
-                node => node.parentFolder === null,
+                node => !node.parentFolder,
             );
             if (params['*']) {
                 const nodeNames = decodeURIComponent(params['*']).split('/');
@@ -324,7 +324,7 @@ const Content = () => {
                             document={selectedDocument}
                             onClose={() => {
                                 navigateToItemId(
-                                    selectedFileNode.parentFolder ?? driveID,
+                                    selectedFileNode.parentFolder || driveID,
                                 );
                                 setSelectedFileNode(undefined);
                             }}


### PR DESCRIPTION
the existing logic for opening files from the url made the assumption that files with no parent folder, i.e. ones directly in the drive, would always have `null` for the `parentFolder` property. However, there is logic in the document drive code that sets this value to `""` instead. This causes the url logic to break.

To fix this for now, I have updated the url logic to treat falsy values for `parentFolder` as meaning the parent is the drive. However, in my opinion it would be better to refactor the code to always use `null` only, since that is more predictable.