### PR TITLE
feat: fix drag and drop accidental rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@powerhousedao/connect",
-    "version": "1.0.0-dev.11",
+    "version": "1.0.0-dev.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@powerhousedao/connect",
-            "version": "1.0.0-dev.11",
+            "version": "1.0.0-dev.12",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@powerhousedao/design-system": "1.0.0-alpha.125",
@@ -19,6 +19,7 @@
                 "electron-squirrel-startup": "^1.0.0",
                 "electron-store": "^8.1.0",
                 "graphql": "^16.8.1",
+                "history": "^5.3.0",
                 "i18next": "^23.7.6",
                 "jotai": "^2.1.0",
                 "localforage": "^1.10.0",
@@ -14960,6 +14961,14 @@
             "dependencies": {
                 "capital-case": "^1.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/history": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.7.6"
             }
         },
         "node_modules/hoist-non-react-statics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0-dev.18",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "@powerhousedao/design-system": "1.0.0-alpha.139",
+                "@powerhousedao/design-system": "1.0.0-alpha.140",
                 "@sentry/react": "^7.109.0",
                 "did-key-creator": "^1.2.0",
                 "document-drive": "1.0.0-alpha.79",
@@ -4532,9 +4532,9 @@
             }
         },
         "node_modules/@powerhousedao/design-system": {
-            "version": "1.0.0-alpha.139",
-            "resolved": "https://registry.npmjs.org/@powerhousedao/design-system/-/design-system-1.0.0-alpha.139.tgz",
-            "integrity": "sha512-PGgSH/H/8jcaGaoYI1ZbbqiPzRkcIQ1D9Nz6gEDhu/6jEKTt+3slOcC6IW61RiroHezjP1OxOpOcDQ4MxUT41w==",
+            "version": "1.0.0-alpha.140",
+            "resolved": "https://registry.npmjs.org/@powerhousedao/design-system/-/design-system-1.0.0-alpha.140.tgz",
+            "integrity": "sha512-wz4APsEORemX7cDozbK7itfXI2z7TWurwyVHIXK/xYe3aNntiNllnPi9arqJT9ZhJr+gTOE4ROt8VnKvQik5lw==",
             "dependencies": {
                 "@internationalized/date": "^3.5.1",
                 "@radix-ui/react-dialog": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@powerhousedao/connect",
-    "version": "1.0.0-dev.17",
+    "version": "1.0.0-dev.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@powerhousedao/connect",
-            "version": "1.0.0-dev.17",
+            "version": "1.0.0-dev.18",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@powerhousedao/design-system": "1.0.0-alpha.139",
@@ -19,6 +19,7 @@
                 "electron-squirrel-startup": "^1.0.0",
                 "electron-store": "^8.1.0",
                 "graphql": "^16.8.1",
+                "history": "^5.3.0",
                 "i18next": "^23.7.6",
                 "jotai": "^2.1.0",
                 "localforage": "^1.10.0",
@@ -14979,6 +14980,14 @@
             "dependencies": {
                 "capital-case": "^1.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/history": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.7.6"
             }
         },
         "node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "xvfb-maybe": "^0.2.1"
     },
     "dependencies": {
-        "@powerhousedao/design-system": "1.0.0-alpha.139",
+        "@powerhousedao/design-system": "1.0.0-alpha.140",
         "@sentry/react": "^7.109.0",
         "did-key-creator": "^1.2.0",
         "document-drive": "1.0.0-alpha.79",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.1.0",
         "graphql": "^16.8.1",
+        "history": "^5.3.0",
         "i18next": "^23.7.6",
         "jotai": "^2.1.0",
         "localforage": "^1.10.0",

--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -8,6 +8,7 @@ import {
     Operation,
     actions,
 } from 'document-model/document';
+import { Action as HistoryAction } from 'history';
 import { useAtomValue } from 'jotai';
 import { useEffect, useMemo } from 'react';
 import { useConnectDid } from 'src/hooks/useConnectCrypto';
@@ -19,6 +20,7 @@ import { themeAtom } from 'src/store/theme';
 import { useUser } from 'src/store/user';
 import { useDocumentDispatch } from 'src/utils/document-model';
 import Button from './button';
+import history from './history';
 
 export interface EditorProps<
     T = unknown,
@@ -112,6 +114,14 @@ export const DocumentEditor: React.FC<IProps> = ({
         window.documentEditorDebugTools?.setDocument(document);
         onChange?.(document);
     }, [document]);
+
+    useEffect(() => {
+        history.listen(update => {
+            if (update.action === HistoryAction.Pop) {
+                onClose();
+            }
+        });
+    }, [onClose]);
 
     function undo() {
         dispatch(actions.undo());

--- a/src/components/history.ts
+++ b/src/components/history.ts
@@ -1,0 +1,5 @@
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+
+export default history;

--- a/src/hooks/useDrivesContainer.ts
+++ b/src/hooks/useDrivesContainer.ts
@@ -105,6 +105,7 @@ export function useDrivesContainer() {
         actions.newVirtualItem({
             id: uuid(),
             label: virtualFolderName,
+            parentFolder,
             path: path.join(item.path, virtualPathName),
             type: 'FOLDER',
             action: 'NEW',
@@ -114,9 +115,8 @@ export function useDrivesContainer() {
     }
 
     async function addNewFolder(item: TreeItem, driveID: string) {
-        const basePathComponents = item.path.split('/').slice(1, -1);
-
         const decodedDriveID = decodeID(driveID);
+        const basePathComponents = item.path.split('/').slice(1, -1);
         const parentFolder = basePathComponents.pop();
         await addFolder(
             decodedDriveID,
@@ -268,6 +268,7 @@ export function useDrivesContainer() {
             id: id,
             label: name,
             path: driveID,
+            parentFolder: null,
             type: driveBaseItemType,
             icon,
             sharingType: sharingType?.toUpperCase() as TreeItemSharingType,
@@ -298,6 +299,7 @@ export function useDrivesContainer() {
                 id: node.id,
                 label: node.name,
                 path: path.join(driveID, getNodePath(node, driveNodes)),
+                parentFolder: node.parentFolder,
                 type: node.kind === 'folder' ? 'FOLDER' : 'FILE',
                 sharingType: sharingType?.toUpperCase() as TreeItemSharingType,
                 availableOffline,
@@ -327,6 +329,7 @@ export function useDrivesContainer() {
                 id: node.id,
                 label: node.name,
                 path: folderPath,
+                parentFolder: node.parentFolder,
                 type: 'FOLDER',
                 sharingType: sharingType?.toUpperCase() as TreeItemSharingType,
                 availableOffline,

--- a/src/hooks/useOnDropEvent.ts
+++ b/src/hooks/useOnDropEvent.ts
@@ -54,9 +54,20 @@ export const useOnDropEvent = () => {
 
             const isMoveOperation = event.dropOperation === 'move';
             const srcId = item.data.id;
-            const srcName = item.data.label
+            const srcName = item.data.label;
+            const itemParentIsDrive =
+                item.data.parentFolder === '' ||
+                item.data.parentFolder === undefined ||
+                item.data.parentFolder === null;
+            const targetIsDrive = decodedTargetId === '';
 
             if (isMoveOperation) {
+                if (itemParentIsDrive && targetIsDrive) {
+                    return;
+                }
+                if (item.data.parentFolder === decodedTargetId) {
+                    return;
+                }
                 await moveNode({
                     decodedDriveId,
                     srcId,


### PR DESCRIPTION
- `parentFolder` property was added to the `TreeItem` type in the design system. Now set that value in the `driveToBaseItems` function so that it can be used in the app
- when attempting to move an item, make sure that we are not trying to move it into the folder it is already in. This happens when you drag an item and then change your mind and drop it. This is the cause of the accidental rename bug.