### PR TITLE
feat: ignore AbortError when user cancels file picker

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -36,19 +36,25 @@ export async function exportFile(
         await downloadFile(document);
         return;
     }
+    try {
+        const fileHandle = await window.showSaveFilePicker({
+            suggestedName: `${document.name || 'Untitled'}.${
+                extension ? `${extension}.` : ''
+            }zip`,
+        });
 
-    const fileHandle = await window.showSaveFilePicker({
-        suggestedName: `${document.name || 'Untitled'}.${
-            extension ? `${extension}.` : ''
-        }zip`,
-    });
-
-    await documentModel.utils.saveToFileHandle(document, fileHandle);
-    const path = (await fileHandle.getFile()).path;
-    if (typeof window !== 'undefined') {
-        window.electronAPI?.fileSaved(document, path);
+        await documentModel.utils.saveToFileHandle(document, fileHandle);
+        const path = (await fileHandle.getFile()).path;
+        if (typeof window !== 'undefined') {
+            window.electronAPI?.fileSaved(document, path);
+        }
+        return path;
+    } catch (e) {
+        // ignores error if user cancelled the file picker
+        if (!(e instanceof DOMException && e.name === 'AbortError')) {
+            throw e;
+        }
     }
-    return path;
 }
 
 export async function loadFile(


### PR DESCRIPTION
Ignores error when user cancels the file picker when exporting a document.

https://powerhouse-u6.sentry.io/issues/5223398848/events/4a4719001b064af8aca64eb6f6444ebc/