### PR TITLE
feat: log catched errors to sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@powerhousedao/connect",
-    "version": "1.0.0-dev.59",
+    "version": "1.0.0-dev.60",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@powerhousedao/connect",
-            "version": "1.0.0-dev.59",
+            "version": "1.0.0-dev.60",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@powerhousedao/design-system": "1.0.0-alpha.159",

--- a/src/app/document-drive.ts
+++ b/src/app/document-drive.ts
@@ -16,6 +16,7 @@ import {
 } from 'document-model/document';
 import { IpcMain, webContents } from 'electron';
 import { join } from 'path';
+import { logger } from 'src/services/logger';
 
 export default (
     documentModels: DocumentModel[],
@@ -54,13 +55,13 @@ export default (
                                     triggers: [],
                                 },
                             })
-                            .catch(console.error);
+                            .catch(logger.error);
                     }
                 })
-                .catch(console.error),
+                .catch(logger.error),
         )
         .then(() => bindEvents(documentDrive))
-        .catch(console.error);
+        .catch(logger.error);
 
     ipcMain.handle('documentDrive:getDrives', () => documentDrive.getDrives());
     ipcMain.handle('documentDrive:getDrive', (_e, id: string) =>

--- a/src/app/sentry.ts
+++ b/src/app/sentry.ts
@@ -9,7 +9,7 @@ import {
 
 import config from '../../connect.config';
 
-export default () => {
+function initSenty() {
     if (!config.sentry.dsn || config.sentry.dsn === '') {
         return;
     }
@@ -18,6 +18,7 @@ export default () => {
         dsn: config.sentry.dsn,
         environment: config.sentry.env,
         integrations: [
+            Sentry.extraErrorDataIntegration({ depth: 5 }),
             Sentry.reactRouterV6BrowserTracingIntegration({
                 useEffect: React.useEffect,
                 useLocation,
@@ -26,10 +27,17 @@ export default () => {
                 matchRoutes,
             }),
             Sentry.replayIntegration(),
+            Sentry.captureConsoleIntegration(),
         ],
-
+        ignoreErrors: [
+            'User is not allowed to create files',
+            'User is not allowed to move documents',
+            'The user aborted a request.',
+        ],
         tracesSampleRate: 1.0,
         replaysSessionSampleRate: 0.1,
         replaysOnErrorSampleRate: 1.0,
     });
-};
+}
+
+initSenty();

--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -19,6 +19,7 @@ import { useConnectCrypto, useConnectDid } from 'src/hooks/useConnectCrypto';
 import { UiNodes } from 'src/hooks/useUiNodes';
 import { useUndoRedoShortcuts } from 'src/hooks/useUndoRedoShortcuts';
 import { useUserPermissions } from 'src/hooks/useUserPermissions';
+import { logger } from 'src/services/logger';
 import { useDocumentModel } from 'src/store/document-model';
 import { useEditor } from 'src/store/editor';
 import { themeAtom } from 'src/store/theme';
@@ -54,7 +55,9 @@ const signOperation = async (
     if (!operation.context) return operation;
     if (!operation.context.signer) return operation;
     if (!reducer) {
-        console.error('Document model does not have a reducer');
+        logger.error(
+            `Document model '${document.documentType}' does not have a reducer`,
+        );
         return operation;
     }
 
@@ -162,7 +165,7 @@ export function DocumentEditor(props: EditorProps) {
                     window.documentEditorDebugTools?.pushOperation(operation);
                     return onAddOperation(op);
                 })
-                .catch(console.error);
+                .catch(logger.error);
         };
 
         _dispatch(addActionContext(action), callback, onErrorCallback);

--- a/src/components/modal/modals/SettingsModal.tsx
+++ b/src/components/modal/modals/SettingsModal.tsx
@@ -13,6 +13,7 @@ import { useConnectConfig } from 'src/hooks/useConnectConfig';
 import { useDocumentDriveServer } from 'src/hooks/useDocumentDriveServer';
 import { useFeatureFlag } from 'src/hooks/useFeatureFlags';
 import { useLogin } from 'src/hooks/useLogin';
+import { logger } from 'src/services/logger';
 import {
     useDocumentModels,
     useFilteredDocumentModels,
@@ -84,7 +85,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = props => {
                         // refreshes the page to reload default drive
                         onRefresh();
                     })
-                    .catch(console.error);
+                    .catch(logger.error);
             },
             onCancel: () => showModal('settingsModal', { onRefresh }),
         });

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -5,6 +5,7 @@ import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
 import { useLoadInitialData } from 'src/hooks/useLoadInitialData';
 import { useLogin } from 'src/hooks/useLogin';
 import { isElectron, isMac } from 'src/hooks/utils';
+import { logger } from 'src/services/logger';
 import Sidebar from './sidebar';
 
 const Root = () => {
@@ -24,7 +25,7 @@ const Root = () => {
             const userDid = decodeURIComponent(userStr);
             searchParams.delete('user');
             setSearchParams(searchParams);
-            login(userDid).catch(console.error);
+            login(userDid).catch(logger.error);
         }
     }, [login, searchParams, setSearchParams]);
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -4,6 +4,7 @@ import { useAtom } from 'jotai';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import { useLogin } from 'src/hooks/useLogin';
+import { logger } from 'src/services/logger';
 import { sidebarCollapsedAtom } from 'src/store';
 import DriveContainer from './drive-container';
 import { useModal } from './modal';
@@ -56,7 +57,7 @@ export default function Sidebar() {
                         There was an error loading drives
                     </div>
                 }
-                onError={console.error}
+                onError={logger.error}
             >
                 <DriveContainer />
             </ErrorBoundary>

--- a/src/hooks/useClientErrorHandler.ts
+++ b/src/hooks/useClientErrorHandler.ts
@@ -1,12 +1,13 @@
+import { LOCAL } from '@powerhousedao/design-system';
 import { PullResponderTrigger } from 'document-drive';
 import {
     PullResponderTriggerData,
     Trigger,
 } from 'document-model-libs/document-drive';
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { logger } from 'src/services/logger';
 import { useDocumentDriveServer } from './useDocumentDriveServer';
 import { useSwitchboard } from './useSwitchboard';
-import { LOCAL } from '@powerhousedao/design-system';
 
 export type ClientErrorHandler = {
     strandsErrorHandler: (
@@ -87,7 +88,7 @@ export const useClientErrorHandler = (): ClientErrorHandler => {
                     delay === DELAY_LIMIT ? delay : delay * 10,
                 );
 
-                console.error(error);
+                logger.error(error);
             } finally {
                 setHandlingInProgress(state =>
                     state.filter(code => code !== handlerCode),
@@ -140,7 +141,7 @@ export const useClientErrorHandler = (): ClientErrorHandler => {
                     }
                 }
             } catch (e: unknown) {
-                console.error(e);
+                logger.error(e);
             } finally {
                 setHandlingInProgress(state =>
                     state.filter(code => code !== handlerCode),

--- a/src/hooks/useConnectCrypto.ts
+++ b/src/hooks/useConnectCrypto.ts
@@ -1,6 +1,7 @@
 import { atom, useAtom } from 'jotai';
 import { useEffect, useMemo } from 'react';
 import type { DID, IConnectCrypto } from 'src/services/crypto';
+import { logger } from 'src/services/logger';
 
 // uses electron connect crypto if available,
 // otherwise dynamically loads browser crypto
@@ -48,7 +49,7 @@ export function useConnectDid(): DID | undefined {
         connectCrypto
             .then(c => c.did())
             .then(did => setDid(did))
-            .catch(console.error);
+            .catch(logger.error);
     });
 
     return did;

--- a/src/hooks/useDocumentDriveServer.ts
+++ b/src/hooks/useDocumentDriveServer.ts
@@ -25,6 +25,7 @@ import {
 } from 'document-model-libs/document-drive';
 import { Document, Operation, utils } from 'document-model/document';
 import { useCallback, useMemo } from 'react';
+import { logger } from 'src/services/logger';
 import { useGetDocumentModel } from 'src/store/document-model';
 import { DefaultDocumentDriveServer } from 'src/utils/document-drive-server';
 import { loadFile } from 'src/utils/file';
@@ -97,7 +98,7 @@ export function useDocumentDriveServer(
                 );
 
                 if (result.status !== 'SUCCESS') {
-                    console.error(result.error);
+                    logger.error(result.error);
                 }
 
                 if (result.operations.length) {
@@ -111,7 +112,7 @@ export function useDocumentDriveServer(
                 }
                 return result.document;
             } catch (error) {
-                console.error(error);
+                logger.error(error);
                 return drive;
             }
         },
@@ -414,7 +415,7 @@ export function useDocumentDriveServer(
             if (result.operations.length) {
                 await refreshDocumentDrives();
             } else if (result.status !== 'SUCCESS') {
-                console.error(
+                logger.error(
                     `Error copying files: ${result.status}`,
                     result.error,
                 );

--- a/src/hooks/useDocumentDrives.ts
+++ b/src/hooks/useDocumentDrives.ts
@@ -4,6 +4,7 @@ import { OperationScope } from 'document-model/document';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 import { useCallback, useMemo } from 'react';
+import { logger } from 'src/services/logger';
 import { ClientErrorHandler } from './useClientErrorHandler';
 
 // map of DocumentDriveServer objects and their Document Drives
@@ -65,11 +66,11 @@ export function useDocumentDrives(server: IDocumentDriveServer) {
                     const drive = await server.getDrive(id);
                     documentDrives.push(drive);
                 } catch (error) {
-                    console.error(error);
+                    logger.error(error);
                 }
             }
         } catch (error) {
-            console.error(error);
+            logger.error(error);
         } finally {
             setDocumentDrives(documentDrives);
         }
@@ -94,7 +95,7 @@ export function useDocumentDrives(server: IDocumentDriveServer) {
                 'syncStatus',
                 async (_event, _status, error) => {
                     if (error) {
-                        console.error(error);
+                        logger.error(error);
                     }
                     await refreshDocumentDrives();
                 },

--- a/src/hooks/useLoadDefaultDrives.ts
+++ b/src/hooks/useLoadDefaultDrives.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { logger } from 'src/services/logger';
 import { useDocumentDriveServer } from './useDocumentDriveServer';
 import { useFeatureFlag } from './useFeatureFlags';
 import defaultConfig from './useFeatureFlags/default-config';
@@ -124,7 +125,7 @@ export const useLoadDefaultDrives = () => {
                             ],
                         })),
                     )
-                    .catch(console.error)
+                    .catch(logger.error)
                     .finally(() => {
                         loadingDrives.current = loadingDrives.current.filter(
                             url => url !== defaultDrive.url,

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -2,6 +2,7 @@ import { atom, useAtom } from 'jotai';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useConnectCrypto } from 'src/hooks/useConnectCrypto';
 import { useRenown } from 'src/hooks/useRenown';
+import { logger } from 'src/services/logger';
 import {
     RENOWN_CHAIN_ID,
     RENOWN_NETWORK_ID,
@@ -62,7 +63,7 @@ export const useLogin = () => {
                 }
             } catch (error) {
                 setStatus('not-authorized');
-                console.error(error);
+                logger.error(error);
             }
         },
         [renown],

--- a/src/hooks/useOpenFile.tsx
+++ b/src/hooks/useOpenFile.tsx
@@ -1,10 +1,11 @@
 import { Document } from 'document-model/document';
+import { logger } from 'src/services/logger';
 import { useGetDocumentModel } from 'src/store/document-model';
 import { loadFile } from 'src/utils/file';
 
 export function useOpenFile(
     onDocument: (document: Document, file: File) => void,
-    onError?: (error: Error) => void
+    onError?: (error: Error) => void,
 ) {
     const getDocumentModel = useGetDocumentModel();
     return async () => {
@@ -18,7 +19,7 @@ export function useOpenFile(
                 throw new Error('File was not recognized.');
             }
         } catch (error) {
-            console.error('Error opening file:', error); // TODO improve error handling
+            logger.error('Error opening file:', error); // TODO improve error handling
             onError?.(error as Error);
         }
     };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -26,7 +26,7 @@
  * ```
  */
 import { createRoot } from 'react-dom/client';
-import initSentry from './app/sentry';
+import './app/sentry';
 import App from './components/app';
 import './i18n';
 import './index.css';
@@ -36,5 +36,4 @@ if (import.meta.env.MODE === 'development') {
     window.documentEditorDebugTools = new DocumentEditorDebugTools();
 }
 
-initSentry();
 createRoot(document.getElementById('app')!).render(App);

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { captureException } from '@sentry/react';
+import { ILogger, setLogger } from 'document-drive/logger';
+
+class ConnectLogger implements ILogger {
+    #logger: ILogger = console;
+
+    set logger(logger: ILogger) {
+        this.#logger = logger;
+    }
+
+    log(...data: any[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.log(...data);
+    }
+
+    info(...data: any[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.info(...data);
+    }
+
+    warn(...data: any[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.warn(...data);
+    }
+
+    error(...data: any[]): void {
+        const errorIndex = data.findIndex(item => item instanceof Error);
+        if (errorIndex) {
+            const error = data.at(errorIndex) as Error;
+            const info = data
+                .slice(0, errorIndex)
+                .concat(data.slice(errorIndex + 1));
+            captureException(error, { data: info });
+        } else if (data.length === 1) {
+            captureException(data.at(0));
+        } else if (data.length > 1) {
+            captureException(data[0], { data: data.slice(1) });
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.error(...data);
+    }
+
+    debug(...data: any[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.debug(...data);
+    }
+
+    trace(...data: any[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return this.#logger.trace(...data);
+    }
+}
+
+export const logger: ILogger = new ConnectLogger();
+
+setLogger(logger);

--- a/src/services/renown/index.ts
+++ b/src/services/renown/index.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { logger } from '../logger';
 import type { IStorage } from '../storage';
 import { getEnsInfo } from '../viem';
 import { RENOWN_URL } from './constants';
@@ -75,7 +76,7 @@ export class Renown {
             this.#updateUser(user);
             return user;
         } catch (error) {
-            console.error(error);
+            logger.error(error);
             this.#updateUser(undefined);
             throw error;
         }

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,3 +1,7 @@
+import {
+    setUser as setSentryUser,
+    type User as SentryUser,
+} from '@sentry/react';
 import { atom, useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useRenown } from 'src/hooks/useRenown';
@@ -10,6 +14,16 @@ const userAtom = atom<User | undefined>(undefined);
 export const useUser = () => {
     const [user, setUser] = useAtom(userAtom);
     const renown = useRenown();
+
+    useEffect(() => {
+        let sentryUser: SentryUser | null = null;
+        if (user) {
+            // saves the user info except the credential
+            const { credential, ...rest } = user;
+            sentryUser = { id: rest.did, username: rest.ens?.name, ...rest };
+        }
+        setSentryUser(sentryUser);
+    }, [user]);
 
     useEffect(() => {
         if (userInit) return;

--- a/src/utils/browser-document-drive.ts
+++ b/src/utils/browser-document-drive.ts
@@ -4,6 +4,7 @@ import { BaseQueueManager } from 'document-drive/queue/base';
 import { DocumentDriveServer } from 'document-drive/server';
 import { BrowserStorage } from 'document-drive/storage/browser';
 import { utils } from 'document-model/document';
+import { logger } from 'src/services/logger';
 import { documentModels } from 'src/store/document-model';
 
 export const BrowserDocumentDriveServer = new DocumentDriveServer(
@@ -34,9 +35,9 @@ BrowserDocumentDriveServer.initialize()
                             listeners: [],
                             triggers: [],
                         },
-                    }).catch(console.error);
+                    }).catch(logger.error);
                 }
             })
-            .catch(console.error),
+            .catch(logger.error),
     )
-    .catch(console.error);
+    .catch(logger.error);

--- a/src/utils/document-model.ts
+++ b/src/utils/document-model.ts
@@ -7,6 +7,7 @@ import type {
     Reducer,
 } from 'document-model/document';
 import { useEffect, useState } from 'react';
+import { logger } from 'src/services/logger';
 
 export type DocumentDispatchCallback<State, A extends Action, LocalState> = (
     operation: Operation,
@@ -42,7 +43,7 @@ type OnErrorHandler = (error: unknown) => void;
 export function useDocumentDispatch<State, A extends Action, LocalState>(
     documentReducer: Reducer<State, A, LocalState> | undefined,
     initialState: Document<State, A, LocalState>,
-    onError: OnErrorHandler = console.error,
+    onError: OnErrorHandler = logger.error,
 ): readonly [
     Document<State, A, LocalState> | undefined,
     DocumentDispatch<State, A, LocalState>,

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,6 @@
 import type { Document, DocumentModel } from 'document-model/document';
 import { utils } from 'document-model/document';
+import { logger } from 'src/services/logger';
 
 const downloadFile = async (document: Document) => {
     const zip = await utils.createZip(document);
@@ -15,7 +16,7 @@ const downloadFile = async (document: Document) => {
 
             window.document.body.removeChild(link);
         })
-        .catch(console.error);
+        .catch(logger.error);
 };
 
 export async function exportFile(


### PR DESCRIPTION
Sentry was only getting error that are not caught and reach the ErrorBoundary component.

I've changed the `console.error` calls to also report to Sentry.

Errors from the document-drive lib will be also sent.

This will probably generate too many errors, we can start ignoring some of them as we understand which are meaningful to report or not.
