### PR TITLE
feat: only open document when we know node is file

### DIFF
--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -16,7 +16,7 @@ import {
 import { useAtomValue } from 'jotai';
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useConnectCrypto, useConnectDid } from 'src/hooks/useConnectCrypto';
-import { UiNodes } from 'src/hooks/useUiNodes';
+import { TUiNodes } from 'src/hooks/useUiNodes';
 import { useUndoRedoShortcuts } from 'src/hooks/useUndoRedoShortcuts';
 import { useUserPermissions } from 'src/hooks/useUserPermissions';
 import { logger } from 'src/services/logger';
@@ -35,7 +35,7 @@ export type EditorProps<
     T = unknown,
     A extends Action = Action,
     LocalState = unknown,
-> = UiNodes & {
+> = TUiNodes & {
     document: Document<T, A, LocalState>;
     onExport: () => void;
     onAddOperation: (operation: Operation) => Promise<void>;

--- a/src/components/file-content-view.tsx
+++ b/src/components/file-content-view.tsx
@@ -2,10 +2,10 @@ import { FileItem, UiFileNode } from '@powerhousedao/design-system';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { UiNodes } from 'src/hooks/useUiNodes';
+import { TUiNodes } from 'src/hooks/useUiNodes';
 import { useWindowSize } from 'src/hooks/useWindowSize';
 
-type Props = UiNodes & {
+type Props = TUiNodes & {
     fileNodes: UiFileNode[];
 };
 

--- a/src/components/folder-view.tsx
+++ b/src/components/folder-view.tsx
@@ -5,13 +5,13 @@ import {
     useDrop,
 } from '@powerhousedao/design-system';
 import { useTranslation } from 'react-i18next';
-import { UiNodes } from 'src/hooks/useUiNodes';
+import { TUiNodes } from 'src/hooks/useUiNodes';
 import { sortUiNodesByName } from 'src/utils';
 import { twMerge } from 'tailwind-merge';
 import { ContentSection } from './content';
 import FileContentView from './file-content-view';
 
-export function FolderView(props: UiNodes) {
+export function FolderView(props: TUiNodes) {
     const { t } = useTranslation();
     const { selectedParentNode } = props;
     const { isDropTarget, dropProps } = useDrop({

--- a/src/hooks/useDocumentDriveServer.ts
+++ b/src/hooks/useDocumentDriveServer.ts
@@ -700,3 +700,5 @@ export function useDocumentDriveServer(
         ],
     );
 }
+
+export type TDocumentDriveServer = ReturnType<typeof useDocumentDriveServer>;

--- a/src/hooks/useUiNodes.ts
+++ b/src/hooks/useUiNodes.ts
@@ -20,6 +20,11 @@ import { DocumentDriveDocument } from 'document-model-libs/document-drive';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useModal } from 'src/components/modal';
+import { useFileNodeDocument } from 'src/store/document-drive';
+import {
+    useFilteredDocumentModels,
+    useGetDocumentModel,
+} from 'src/store/document-model';
 import { getNodeOptions } from 'src/utils/drive-sections';
 import { makeNodeSlugFromNodeName } from 'src/utils/slug';
 import { useDocumentDriveById } from './useDocumentDriveById';
@@ -61,6 +66,12 @@ export function useUiNodes() {
     const openSwitchboardLink = useOpenSwitchboardLink(selectedDriveNode?.id);
     const userPermissions = useUserPermissions();
     const nodeOptions = getNodeOptions();
+    const documentModels = useFilteredDocumentModels();
+    const getDocumentModel = useGetDocumentModel();
+    const fileNodeDocument = useFileNodeDocument({
+        ...uiNodesContext,
+        ...documentDriveServer,
+    });
 
     const makeUiDriveNode = useCallback(
         async (drive: DocumentDriveDocument) => {
@@ -493,8 +504,10 @@ export function useUiNodes() {
             ...uiNodesContext,
             ...userPermissions,
             ...selectedDocumentDrive,
+            ...fileNodeDocument,
             nodeOptions,
             driveNodesBySharingType,
+            documentModels,
             onAddFolder,
             onAddFile,
             onCopyNode,
@@ -511,14 +524,17 @@ export function useUiNodes() {
             onAddTrigger,
             onRemoveTrigger,
             onAddInvalidTrigger,
+            getDocumentModel,
         }),
         [
             documentDriveServer,
             uiNodesContext,
             userPermissions,
             selectedDocumentDrive,
+            fileNodeDocument,
             nodeOptions,
             driveNodesBySharingType,
+            documentModels,
             onAddFolder,
             onAddFile,
             onCopyNode,
@@ -535,8 +551,9 @@ export function useUiNodes() {
             onAddTrigger,
             onRemoveTrigger,
             onAddInvalidTrigger,
+            getDocumentModel,
         ],
     );
 }
 
-export type UiNodes = ReturnType<typeof useUiNodes>;
+export type TUiNodes = ReturnType<typeof useUiNodes>;

--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -8,14 +8,8 @@ import FolderView from 'src/components/folder-view';
 import { useModal } from 'src/components/modal';
 import { SearchBar } from 'src/components/search-bar';
 import { useConnectConfig } from 'src/hooks/useConnectConfig';
-import { useDocumentDriveServer } from 'src/hooks/useDocumentDriveServer';
 import { useNodeNavigation } from 'src/hooks/useNodeNavigation';
 import { useUiNodes } from 'src/hooks/useUiNodes';
-import { useFileNodeDocument } from 'src/store/document-drive';
-import {
-    useFilteredDocumentModels,
-    useGetDocumentModel,
-} from 'src/store/document-model';
 import { usePreloadEditor } from 'src/store/editor';
 import { exportFile } from 'src/utils';
 import { validateDocument } from 'src/utils/validate-document';
@@ -38,15 +32,17 @@ const Content = () => {
         selectedParentNode,
         isRemoteDrive,
         isAllowedToCreateDocuments,
+        selectedDocument,
+        documentModels,
         setSelectedNode,
         openSwitchboardLink,
+        setSelectedDocument,
+        addOperationToSelectedDocument,
+        addFile,
+        renameNode,
+        getDocumentModel,
     } = useUiNodes();
     const { showModal } = useModal();
-    const { addFile, renameNode } = useDocumentDriveServer();
-    const documentModels = useFilteredDocumentModels();
-    const getDocumentModel = useGetDocumentModel();
-    const [selectedDocument, setSelectedDocument, addOperation] =
-        useFileNodeDocument(selectedDriveNode?.id, selectedNode?.id);
     const preloadEditor = usePreloadEditor();
     useNodeNavigation();
 
@@ -79,14 +75,14 @@ const Content = () => {
         });
     }, [selectedDriveNode, selectedNode, addFile]);
 
-    async function handleAddOperation(operation: Operation) {
+    async function handleAddOperationToSelectedDocument(operation: Operation) {
         if (!selectedDocument) {
             throw new Error('No document selected');
         }
-        if (!addOperation) {
+        if (!addOperationToSelectedDocument) {
             throw new Error('No add operation function defined');
         }
-        await addOperation(operation);
+        await addOperationToSelectedDocument(operation);
     }
 
     function createDocument(documentModel: DocumentModel) {
@@ -162,7 +158,7 @@ const Content = () => {
                         document={selectedDocument}
                         onChange={onDocumentChangeHandler}
                         onExport={() => exportDocument(selectedDocument)}
-                        onAddOperation={handleAddOperation}
+                        onAddOperation={handleAddOperationToSelectedDocument}
                         {...(isRemoteDrive && { onOpenSwitchboardLink })}
                     />
                 </div>


### PR DESCRIPTION
We need to make sure that a given node is in fact a file node before we attempt to open it as a document.

I have added checks to do this in the `useFileNodeDocument` hook. Since this logic is inextricably linked to the nodes, I have moved the invocation of this hook into the `useUiNodes` hook. This way, we can also get the document data from the same hook for convenience. This also prevents possible confusion.

I have also renamed the `addOperation` function exported by `useFileNodeDocument` to avoid confusion with the `addOperation` function exported by `useDocumentDriveServer`.