### PR TITLE
[WIP] feat: added loading screen implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@powerhousedao/connect",
-    "version": "1.0.0-dev.66",
+    "version": "1.0.0-dev.70",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@powerhousedao/connect",
-            "version": "1.0.0-dev.66",
+            "version": "1.0.0-dev.70",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "@powerhousedao/design-system": "1.0.0-alpha.160",
+                "@powerhousedao/design-system": "1.0.0-alpha.162",
                 "@sentry/react": "^7.109.0",
                 "@tanstack/react-virtual": "^3.8.1",
                 "did-key-creator": "^1.2.0",
@@ -4365,15 +4365,15 @@
             }
         },
         "node_modules/@emotion/babel-plugin": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-            "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+            "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/serialize": "^1.1.2",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.2.0",
                 "babel-plugin-macros": "^3.1.0",
                 "convert-source-map": "^1.5.0",
                 "escape-string-regexp": "^4.0.0",
@@ -4396,39 +4396,39 @@
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-            "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+            "version": "11.13.1",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+            "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
             "dependencies": {
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/sheet": "^1.2.2",
-                "@emotion/utils": "^1.2.1",
-                "@emotion/weak-memoize": "^0.3.1",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.0",
+                "@emotion/weak-memoize": "^0.4.0",
                 "stylis": "4.2.0"
             }
         },
         "node_modules/@emotion/hash": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
         },
         "node_modules/@emotion/memoize": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
         },
         "node_modules/@emotion/react": {
-            "version": "11.11.4",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
-            "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+            "version": "11.13.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.0.tgz",
+            "integrity": "sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.11.0",
-                "@emotion/cache": "^11.11.0",
-                "@emotion/serialize": "^1.1.3",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-                "@emotion/utils": "^1.2.1",
-                "@emotion/weak-memoize": "^0.3.1",
+                "@emotion/babel-plugin": "^11.12.0",
+                "@emotion/cache": "^11.13.0",
+                "@emotion/serialize": "^1.3.0",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+                "@emotion/utils": "^1.4.0",
+                "@emotion/weak-memoize": "^0.4.0",
                 "hoist-non-react-statics": "^3.3.1"
             },
             "peerDependencies": {
@@ -4441,44 +4441,44 @@
             }
         },
         "node_modules/@emotion/serialize": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
-            "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.0.tgz",
+            "integrity": "sha512-jACuBa9SlYajnpIVXB+XOXnfJHyckDfe6fOpORIM6yhBDlqGuExvDdZYHDQGoDf3bZXGv7tNr+LpLjJqiEQ6EA==",
             "dependencies": {
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/unitless": "^0.8.1",
-                "@emotion/utils": "^1.2.1",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.9.0",
+                "@emotion/utils": "^1.4.0",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@emotion/sheet": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-            "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
         },
         "node_modules/@emotion/unitless": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.9.0.tgz",
+            "integrity": "sha512-TP6GgNZtmtFaFcsOgExdnfxLLpRDla4Q66tnenA9CktvVSdNKDvMVuUah4QvWPIpNjrWsGg3qeGo9a43QooGZQ=="
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+            "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-            "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
+            "integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ=="
         },
         "node_modules/@emotion/weak-memoize": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-            "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -5000,20 +5000,20 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
-            "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+            "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.4"
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
-            "integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+            "version": "1.6.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+            "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
-                "@floating-ui/utils": "^0.2.4"
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "node_modules/@floating-ui/react-dom": {
@@ -5029,9 +5029,9 @@
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
-            "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+            "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
         },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
@@ -5568,9 +5568,9 @@
             }
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
-            "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+            "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
         },
         "node_modules/@lit/reactive-element": {
             "version": "1.6.3",
@@ -5615,6 +5615,38 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/json-rpc-engine": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-7.3.3.tgz",
+            "integrity": "sha512-dwZPq8wx9yV3IX2caLi9q9xZBw2XeIoYqdyihDDDpuHVCEiqadJLwqM3zy+uwf6F1QYQ65A8aOMQg1Uw7LMLNg==",
+            "dependencies": {
+                "@metamask/rpc-errors": "^6.2.1",
+                "@metamask/safe-event-emitter": "^3.0.0",
+                "@metamask/utils": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/json-rpc-engine/node_modules/@metamask/utils": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-8.5.0.tgz",
+            "integrity": "sha512-I6bkduevXb72TIM9q2LRO63JSsF9EXduh3sBr9oybNX2hNNpr/j1tEjXrsG0Uabm4MJ1xkGAQEMwifvKZIkyxQ==",
+            "dependencies": {
+                "@ethereumjs/tx": "^4.2.0",
+                "@metamask/superstruct": "^3.0.0",
+                "@noble/hashes": "^1.3.1",
+                "@scure/base": "^1.1.3",
+                "@types/debug": "^4.1.7",
+                "debug": "^4.3.4",
+                "pony-cause": "^2.1.10",
+                "semver": "^7.5.4",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/utils": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
@@ -5631,9 +5663,9 @@
             }
         },
         "node_modules/@metamask/json-rpc-engine": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-7.3.3.tgz",
-            "integrity": "sha512-dwZPq8wx9yV3IX2caLi9q9xZBw2XeIoYqdyihDDDpuHVCEiqadJLwqM3zy+uwf6F1QYQ65A8aOMQg1Uw7LMLNg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-8.0.2.tgz",
+            "integrity": "sha512-IoQPmql8q7ABLruW7i4EYVHWUbF74yrp63bRuXV5Zf9BQwcn5H9Ww1eLtROYvI1bUXwOiHZ6qT5CWTrDc/t/AA==",
             "dependencies": {
                 "@metamask/rpc-errors": "^6.2.1",
                 "@metamask/safe-event-emitter": "^3.0.0",
@@ -5644,11 +5676,11 @@
             }
         },
         "node_modules/@metamask/json-rpc-middleware-stream": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-6.0.2.tgz",
-            "integrity": "sha512-jtyx3PRfc1kqoLpYveIVQNwsxYKefc64/LCl9h9Da1m3nUKEvypbYuXSIwi237qvOjKmNHQKsDOZg6f4uBf62Q==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-7.0.2.tgz",
+            "integrity": "sha512-yUdzsJK04Ev98Ck4D7lmRNQ8FPioXYhEUZOMS01LXW8qTvPGiRVXmVltj2p4wrLkh0vW7u6nv0mNl5xzC5Qmfg==",
             "dependencies": {
-                "@metamask/json-rpc-engine": "^7.3.2",
+                "@metamask/json-rpc-engine": "^8.0.2",
                 "@metamask/safe-event-emitter": "^3.0.0",
                 "@metamask/utils": "^8.3.0",
                 "readable-stream": "^3.6.2"
@@ -5704,15 +5736,15 @@
             }
         },
         "node_modules/@metamask/providers": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-15.0.0.tgz",
-            "integrity": "sha512-FXvL1NQNl6I7fMOJTfQYcBlBZ33vSlm6w80cMpmn8sJh0Lb7wcBpe02UwBsNlARnI+Qsr26XeDs6WHUHQh8CuA==",
+            "version": "16.1.0",
+            "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-16.1.0.tgz",
+            "integrity": "sha512-znVCvux30+3SaUwcUGaSf+pUckzT5ukPRpcBmy+muBLC0yaWnBcvDqGfcsw6CBIenUdFrVoAFa8B6jsuCY/a+g==",
             "dependencies": {
-                "@metamask/json-rpc-engine": "^7.3.2",
-                "@metamask/json-rpc-middleware-stream": "^6.0.2",
+                "@metamask/json-rpc-engine": "^8.0.1",
+                "@metamask/json-rpc-middleware-stream": "^7.0.1",
                 "@metamask/object-multiplex": "^2.0.0",
                 "@metamask/rpc-errors": "^6.2.1",
-                "@metamask/safe-event-emitter": "^3.0.0",
+                "@metamask/safe-event-emitter": "^3.1.1",
                 "@metamask/utils": "^8.3.0",
                 "detect-browser": "^5.2.0",
                 "extension-port-stream": "^3.0.0",
@@ -5778,14 +5810,14 @@
             }
         },
         "node_modules/@metamask/sdk": {
-            "version": "0.26.4",
-            "resolved": "https://registry.npmjs.org/@metamask/sdk/-/sdk-0.26.4.tgz",
-            "integrity": "sha512-9Yh41KJkD9RhW0lRijnQzPV0ptblLorLdTsf5GnAl3yE72QIfaPBtsDxzLtX+0QLppiFfj7o8vRBYvBApG9k+Q==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@metamask/sdk/-/sdk-0.27.0.tgz",
+            "integrity": "sha512-6sMjr/0qR700X1svPGEQ4rBdtccidBLeTC27fYQc7r9ROgSixB1DUUAyu/LoySVqt3Hu/Zm7NnAHXuT228ht7A==",
             "dependencies": {
                 "@metamask/onboarding": "^1.0.1",
-                "@metamask/providers": "^15.0.0",
-                "@metamask/sdk-communication-layer": "0.26.4",
-                "@metamask/sdk-install-modal-web": "0.26.4",
+                "@metamask/providers": "16.1.0",
+                "@metamask/sdk-communication-layer": "0.27.0",
+                "@metamask/sdk-install-modal-web": "0.26.5",
                 "@types/dom-screen-wake-lock": "^1.0.0",
                 "bowser": "^2.9.0",
                 "cross-fetch": "^4.0.0",
@@ -5819,14 +5851,14 @@
             }
         },
         "node_modules/@metamask/sdk-install-modal-web": {
-            "version": "0.26.4",
-            "resolved": "https://registry.npmjs.org/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.26.4.tgz",
-            "integrity": "sha512-7Cx7ZsaExbMwghlRrUWWI0Ksg0m7K60LtMjfuDpjvjWqoZa9MoPxitGDEXNbLaqvKn39ebPvNcPzQ6czA4ilTw==",
+            "version": "0.26.5",
+            "resolved": "https://registry.npmjs.org/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.26.5.tgz",
+            "integrity": "sha512-qVA9Nk+NorGx5hXyODy5wskptE8R7RNYTYt49VbQpJogqbbVe1dnJ98+KaA43PBN4XYMCXmcIhULNiEHGsLynA==",
             "dependencies": {
                 "qr-code-styling": "^1.6.0-rc.1"
             },
             "peerDependencies": {
-                "i18next": "23.2.3",
+                "i18next": "23.11.5",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-native": "*"
@@ -5860,9 +5892,9 @@
             }
         },
         "node_modules/@metamask/sdk/node_modules/@metamask/sdk-communication-layer": {
-            "version": "0.26.4",
-            "resolved": "https://registry.npmjs.org/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.26.4.tgz",
-            "integrity": "sha512-+X4GEc5mV1gWK4moSswVlKsUh+RsA48qPlkxBLTUxQODSnyBe0TRMxE6mH+bSrfponnTzvBkGUXyEjvDwDjDHw==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.27.0.tgz",
+            "integrity": "sha512-G9LCaQzIqp5WmUmvHN6UUdjWrBh67MbRobmbbs5fcc2+9XFhj3vBgtyleUYjun91jSlPHoZeo+f/Pj4/WoPIJg==",
             "dependencies": {
                 "bufferutil": "^4.0.8",
                 "date-fns": "^2.29.3",
@@ -5918,28 +5950,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@metamask/sdk/node_modules/i18next": {
-            "version": "23.11.5",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
-            "integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-                }
-            ],
-            "dependencies": {
-                "@babel/runtime": "^7.23.2"
-            }
-        },
         "node_modules/@metamask/sdk/node_modules/memoize-one": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -5989,22 +5999,22 @@
             "peer": true
         },
         "node_modules/@metamask/sdk/node_modules/react-native": {
-            "version": "0.74.3",
-            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.3.tgz",
-            "integrity": "sha512-UFutCC6WEw6HkxlcpQ2BemKqi0JkwrgDchYB5Svi8Sp4Xwt4HA6LGEjNQgZ+3KM44bjyFRpofQym0uh0jACGng==",
+            "version": "0.74.5",
+            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.5.tgz",
+            "integrity": "sha512-Bgg2WvxaGODukJMTZFTZBNMKVaROHLwSb8VAGEdrlvKwfb1hHg/3aXTUICYk7dwgAnb+INbGMwnF8yeAgIUmqw==",
             "peer": true,
             "dependencies": {
                 "@jest/create-cache-key-function": "^29.6.3",
                 "@react-native-community/cli": "13.6.9",
                 "@react-native-community/cli-platform-android": "13.6.9",
                 "@react-native-community/cli-platform-ios": "13.6.9",
-                "@react-native/assets-registry": "0.74.85",
-                "@react-native/codegen": "0.74.85",
-                "@react-native/community-cli-plugin": "0.74.85",
-                "@react-native/gradle-plugin": "0.74.85",
-                "@react-native/js-polyfills": "0.74.85",
-                "@react-native/normalize-colors": "0.74.85",
-                "@react-native/virtualized-lists": "0.74.85",
+                "@react-native/assets-registry": "0.74.87",
+                "@react-native/codegen": "0.74.87",
+                "@react-native/community-cli-plugin": "0.74.87",
+                "@react-native/gradle-plugin": "0.74.87",
+                "@react-native/js-polyfills": "0.74.87",
+                "@react-native/normalize-colors": "0.74.87",
+                "@react-native/virtualized-lists": "0.74.87",
                 "abort-controller": "^3.0.0",
                 "anser": "^1.4.9",
                 "ansi-regex": "^5.0.0",
@@ -6062,9 +6072,9 @@
             }
         },
         "node_modules/@metamask/sdk/node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.85.tgz",
-            "integrity": "sha512-jx2Zw0qlZteoQ+0KxRc7s4drsljLBEP534FaNZ950e9+CN9nVkLsV6rigcTjDR8wjKMSBWhKf0C0C3egYz7Ehg==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.87.tgz",
+            "integrity": "sha512-lsGxoFMb0lyK/MiplNKJpD+A1EoEUumkLrCjH4Ht+ZlG8S0BfCxmskLZ6qXn3BiDSkLjfjI/qyZ3pnxNBvkXpQ==",
             "peer": true,
             "dependencies": {
                 "invariant": "^2.2.4",
@@ -6819,9 +6829,9 @@
             }
         },
         "node_modules/@powerhousedao/design-system": {
-            "version": "1.0.0-alpha.160",
-            "resolved": "https://registry.npmjs.org/@powerhousedao/design-system/-/design-system-1.0.0-alpha.160.tgz",
-            "integrity": "sha512-QL/tyyXnguac5vgVOKPC7NzQ9ot/PaMyJ9EJeYBDx8KufmuYFPUM2pRx9Df/5Q5yQ+XK46mOO2HsSVuVYWfgdw==",
+            "version": "1.0.0-alpha.162",
+            "resolved": "https://registry.npmjs.org/@powerhousedao/design-system/-/design-system-1.0.0-alpha.162.tgz",
+            "integrity": "sha512-ui7VA9vCvD+BIiAdwYeHaCeu3gYOcJe5ZLS0ZKHCSGCVchQxM/POpcVzbeO8hF/br5Hx751ktUdp4w4O5cRi+g==",
             "dependencies": {
                 "@internationalized/date": "^3.5.1",
                 "@radix-ui/react-dialog": "^1.0.5",
@@ -7937,30 +7947,30 @@
             }
         },
         "node_modules/@react-native/assets-registry": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.85.tgz",
-            "integrity": "sha512-59YmIQxfGDw4aP9S/nAM+sjSFdW8fUP6fsqczCcXgL2YVEjyER9XCaUT0J1K+PdHep8pi05KUgIKUds8P3jbmA==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.87.tgz",
+            "integrity": "sha512-1XmRhqQchN+pXPKEKYdpJlwESxVomJOxtEnIkbo7GAlaN2sym84fHEGDXAjLilih5GVPpcpSmFzTy8jx3LtaFg==",
             "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/babel-plugin-codegen": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.85.tgz",
-            "integrity": "sha512-48TSDclRB5OMXiImiJkLxyCfRyLsqkCgI8buugCZzvXcYslfV7gCvcyFyQldtcOmerV+CK4RAj7QS4hmB5Mr8Q==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.87.tgz",
+            "integrity": "sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==",
             "peer": true,
             "dependencies": {
-                "@react-native/codegen": "0.74.85"
+                "@react-native/codegen": "0.74.87"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/babel-preset": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.85.tgz",
-            "integrity": "sha512-yMHUlN8INbK5BBwiBuQMftdWkpm1IgCsoJTKcGD2OpSgZhwwm8RUSvGhdRMzB2w7bsqqBmaEMleGtW6aCR7B9w==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.87.tgz",
+            "integrity": "sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.0",
@@ -8003,7 +8013,7 @@
                 "@babel/plugin-transform-typescript": "^7.5.0",
                 "@babel/plugin-transform-unicode-regex": "^7.0.0",
                 "@babel/template": "^7.0.0",
-                "@react-native/babel-plugin-codegen": "0.74.85",
+                "@react-native/babel-plugin-codegen": "0.74.87",
                 "babel-plugin-transform-flow-enums": "^0.0.2",
                 "react-refresh": "^0.14.0"
             },
@@ -8015,9 +8025,9 @@
             }
         },
         "node_modules/@react-native/codegen": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.85.tgz",
-            "integrity": "sha512-N7QwoS4Hq/uQmoH83Ewedy6D0M7xbQsOU3OMcQf0eY3ltQ7S2hd9/R4UTalQWRn1OUJfXR6OG12QJ4FStKgV6Q==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.87.tgz",
+            "integrity": "sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==",
             "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.0",
@@ -8133,15 +8143,15 @@
             }
         },
         "node_modules/@react-native/community-cli-plugin": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.85.tgz",
-            "integrity": "sha512-ODzND33eA2owAY3g9jgCdqB+BjAh8qJ7dvmSotXgrgDYr3MJMpd8gvHTIPe2fg4Kab+wk8uipRhrE0i0RYMwtQ==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.87.tgz",
+            "integrity": "sha512-EgJG9lSr8x3X67dHQKQvU6EkO+3ksVlJHYIVv6U/AmW9dN80BEFxgYbSJ7icXS4wri7m4kHdgeq2PQ7/3vvrTQ==",
             "peer": true,
             "dependencies": {
                 "@react-native-community/cli-server-api": "13.6.9",
                 "@react-native-community/cli-tools": "13.6.9",
-                "@react-native/dev-middleware": "0.74.85",
-                "@react-native/metro-babel-transformer": "0.74.85",
+                "@react-native/dev-middleware": "0.74.87",
+                "@react-native/metro-babel-transformer": "0.74.87",
                 "chalk": "^4.0.0",
                 "execa": "^5.1.1",
                 "metro": "^0.80.3",
@@ -8156,22 +8166,22 @@
             }
         },
         "node_modules/@react-native/debugger-frontend": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.85.tgz",
-            "integrity": "sha512-gUIhhpsYLUTYWlWw4vGztyHaX/kNlgVspSvKe2XaPA7o3jYKUoNLc3Ov7u70u/MBWfKdcEffWq44eSe3j3s5JQ==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.87.tgz",
+            "integrity": "sha512-MN95DJLYTv4EqJc+9JajA3AJZSBYJz2QEJ3uWlHrOky2vKrbbRVaW1ityTmaZa2OXIvNc6CZwSRSE7xCoHbXhQ==",
             "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/dev-middleware": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.85.tgz",
-            "integrity": "sha512-BRmgCK5vnMmHaKRO+h8PKJmHHH3E6JFuerrcfE3wG2eZ1bcSr+QTu8DAlpxsDWvJvHpCi8tRJGauxd+Ssj/c7w==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.87.tgz",
+            "integrity": "sha512-7TmZ3hTHwooYgIHqc/z87BMe1ryrIqAUi+AF7vsD+EHCGxHFdMjSpf1BZ2SUPXuLnF2cTiTfV2RwhbPzx0tYIA==",
             "peer": true,
             "dependencies": {
                 "@isaacs/ttlcache": "^1.4.1",
-                "@react-native/debugger-frontend": "0.74.85",
+                "@react-native/debugger-frontend": "0.74.87",
                 "@rnx-kit/chromium-edge-launcher": "^1.0.0",
                 "chrome-launcher": "^0.15.2",
                 "connect": "^3.6.5",
@@ -8238,31 +8248,31 @@
             }
         },
         "node_modules/@react-native/gradle-plugin": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.85.tgz",
-            "integrity": "sha512-1VQSLukJzaVMn1MYcs8Weo1nUW8xCas2XU1KuoV7OJPk6xPnEBFJmapmEGP5mWeEy7kcTXJmddEgy1wwW0tcig==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.87.tgz",
+            "integrity": "sha512-T+VX0N1qP+U9V4oAtn7FTX7pfsoVkd1ocyw9swYXgJqU2fK7hC9famW7b3s3ZiufPGPr1VPJe2TVGtSopBjL6A==",
             "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/js-polyfills": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.85.tgz",
-            "integrity": "sha512-gp4Rg9le3lVZeW7Cie6qLfekvRKZuhJ3LKgi1SFB4N154z1wIclypAJXVXgWBsy8JKJfTwRI+sffC4qZDlvzrg==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.87.tgz",
+            "integrity": "sha512-M5Evdn76CuVEF0GsaXiGi95CBZ4IWubHqwXxV9vG9CC9kq0PSkoM2Pn7Lx7dgyp4vT7ccJ8a3IwHbe+5KJRnpw==",
             "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/metro-babel-transformer": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.85.tgz",
-            "integrity": "sha512-JIrXqEwhTvWPtGArgMptIPGstMdXQIkwSjKVYt+7VC4a9Pw1GurIWanIJheEW6ZuCVvTc0VZkwglFz9JVjzDjA==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.87.tgz",
+            "integrity": "sha512-UsJCO24sNax2NSPBmV1zLEVVNkS88kcgAiYrZHtYSwSjpl4WZ656tIeedBfiySdJ94Hr3kQmBYLipV5zk0NI1A==",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.0",
-                "@react-native/babel-preset": "0.74.85",
+                "@react-native/babel-preset": "0.74.87",
                 "hermes-parser": "0.19.1",
                 "nullthrows": "^1.1.1"
             },
@@ -8274,9 +8284,9 @@
             }
         },
         "node_modules/@react-native/normalize-colors": {
-            "version": "0.74.85",
-            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.85.tgz",
-            "integrity": "sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==",
+            "version": "0.74.87",
+            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.87.tgz",
+            "integrity": "sha512-Xh7Nyk/MPefkb0Itl5Z+3oOobeG9lfLb7ZOY2DKpFnoCE1TzBmib9vMNdFaLdSxLIP+Ec6icgKtdzYg8QUPYzA==",
             "peer": true
         },
         "node_modules/@react-stately/calendar": {
@@ -8915,9 +8925,9 @@
             }
         },
         "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/@types/node": {
-            "version": "18.19.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-            "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+            "version": "18.19.44",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+            "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
             "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -9150,160 +9160,27 @@
             ]
         },
         "node_modules/@safe-global/safe-apps-provider": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.1.tgz",
-            "integrity": "sha512-V4a05A3EgJcriqtDoJklDz1BOinWhC6P0hjUSxshA4KOZM7rGPCTto/usXs09zr1vvL28evl/NldSTv97j2bmg==",
+            "version": "0.18.3",
+            "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.3.tgz",
+            "integrity": "sha512-f/0cNv3S4v7p8rowAjj0hDCg8Q8P/wBjp5twkNWeBdvd0RDr7BuRBPPk74LCqmjQ82P+1ltLlkmVFSmxTIT7XQ==",
             "dependencies": {
-                "@safe-global/safe-apps-sdk": "^8.1.0",
+                "@safe-global/safe-apps-sdk": "^9.1.0",
                 "events": "^3.3.0"
             }
         },
         "node_modules/@safe-global/safe-apps-sdk": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz",
-            "integrity": "sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
+            "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
             "dependencies": {
                 "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
-                "viem": "^1.0.0"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/@noble/curves": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-            "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-            "dependencies": {
-                "@noble/hashes": "1.3.2"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/@noble/hashes": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/@scure/bip32": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-            "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-            "dependencies": {
-                "@noble/curves": "~1.2.0",
-                "@noble/hashes": "~1.3.2",
-                "@scure/base": "~1.1.2"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/@scure/bip39": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-            "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-            "dependencies": {
-                "@noble/hashes": "~1.3.0",
-                "@scure/base": "~1.1.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/abitype": {
-            "version": "0.9.8",
-            "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-            "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/wagmi-dev"
-                }
-            ],
-            "peerDependencies": {
-                "typescript": ">=5.0.4",
-                "zod": "^3 >=3.19.1"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                },
-                "zod": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/isows": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-            "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/wagmi-dev"
-                }
-            ],
-            "peerDependencies": {
-                "ws": "*"
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/viem": {
-            "version": "1.21.4",
-            "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
-            "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/wevm"
-                }
-            ],
-            "dependencies": {
-                "@adraffy/ens-normalize": "1.10.0",
-                "@noble/curves": "1.2.0",
-                "@noble/hashes": "1.3.2",
-                "@scure/bip32": "1.3.2",
-                "@scure/bip39": "1.2.1",
-                "abitype": "0.9.8",
-                "isows": "1.0.3",
-                "ws": "8.13.0"
-            },
-            "peerDependencies": {
-                "typescript": ">=5.0.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@safe-global/safe-apps-sdk/node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
+                "viem": "^2.1.1"
             }
         },
         "node_modules/@safe-global/safe-gateway-typescript-sdk": {
-            "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.0.tgz",
-            "integrity": "sha512-QKgucFMloZ7S23X70U6OmFaRxfX2O52xBAZFIDeW9n+uiANG+JYUiJv6UC0/eVNto+CU/dOVnpqRDhr6/ElKDg==",
+            "version": "3.22.2",
+            "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.2.tgz",
+            "integrity": "sha512-Y0yAxRaB98LFp2Dm+ACZqBSdAmI3FlpH/LjxOZ94g/ouuDJecSq0iR26XZ5QDuEL8Rf+L4jBJaoDC08CD0KkJw==",
             "engines": {
                 "node": ">=16"
             }
@@ -10714,20 +10591,20 @@
             }
         },
         "node_modules/@tanstack/query-core": {
-            "version": "5.51.1",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.51.1.tgz",
-            "integrity": "sha512-fJBMQMpo8/KSsWW5ratJR5+IFr7YNJ3K2kfP9l5XObYHsgfVy1w3FJUWU4FT2fj7+JMaEg33zOcNDBo0LMwHnw==",
+            "version": "5.51.21",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.51.21.tgz",
+            "integrity": "sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@tanstack/react-query": {
-            "version": "5.51.1",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.1.tgz",
-            "integrity": "sha512-s47HKFnQ4HOJAHoIiXcpna/roMMPZJPy6fJ6p4ZNVn8+/onlLBEDd1+xc8OnDuwgvecqkZD7Z2mnSRbcWefrKw==",
+            "version": "5.51.23",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.23.tgz",
+            "integrity": "sha512-CfJCfX45nnVIZjQBRYYtvVMIsGgWLKLYC4xcUiYEey671n1alvTZoCBaU9B85O8mF/tx9LPyrI04A6Bs2THv4A==",
             "dependencies": {
-                "@tanstack/query-core": "5.51.1"
+                "@tanstack/query-core": "5.51.21"
             },
             "funding": {
                 "type": "github",
@@ -11162,9 +11039,9 @@
             }
         },
         "node_modules/@types/react-transition-group": {
-            "version": "4.4.10",
-            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-            "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+            "version": "4.4.11",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+            "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -11254,9 +11131,9 @@
             "dev": true
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.32",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-            "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "peer": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -11590,15 +11467,15 @@
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         },
         "node_modules/@wagmi/connectors": {
-            "version": "5.0.23",
-            "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.0.23.tgz",
-            "integrity": "sha512-0VZaxi0W9jZ9tYvLdFULxS0JhhJkU6kIhQ/Ovw6VRvL03pLSZN93NFZ8W5X+KYXljko+ZAH11xNUsOgpTlcKdw==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.1.5.tgz",
+            "integrity": "sha512-z+UAfwfTqVldoNxUFffHPcc/ets3UP1ehXE6b9k9ZDaih8VdZJRGz84qLjx+GVnI/+FrHfFwPPD9C2YYd2azww==",
             "dependencies": {
                 "@coinbase/wallet-sdk": "4.0.4",
-                "@metamask/sdk": "0.26.4",
-                "@safe-global/safe-apps-provider": "0.18.1",
-                "@safe-global/safe-apps-sdk": "8.1.0",
-                "@walletconnect/ethereum-provider": "2.13.0",
+                "@metamask/sdk": "0.27.0",
+                "@safe-global/safe-apps-provider": "0.18.3",
+                "@safe-global/safe-apps-sdk": "9.1.0",
+                "@walletconnect/ethereum-provider": "2.14.0",
                 "@walletconnect/modal": "2.6.2",
                 "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3"
             },
@@ -11606,7 +11483,7 @@
                 "url": "https://github.com/sponsors/wevm"
             },
             "peerDependencies": {
-                "@wagmi/core": "2.11.8",
+                "@wagmi/core": "2.13.4",
                 "typescript": ">=5.0.4",
                 "viem": "2.x"
             },
@@ -11617,9 +11494,9 @@
             }
         },
         "node_modules/@wagmi/core": {
-            "version": "2.11.8",
-            "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.11.8.tgz",
-            "integrity": "sha512-ZdhFcdS6DITiIr8CbFFjXALxNyY9CNqfed8FzOK3Qvhm5myGW8fn9BmpFhcu5fk7oWQmvFQd9psCjbZBtm3Ulg==",
+            "version": "2.13.4",
+            "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.13.4.tgz",
+            "integrity": "sha512-J6gfxHYr8SCc/BzEa712LnI+qLFs5K2nBLupwQqQl4WiAlCu8SdcpbZokqiwfCMYhIRMj0+YFEP9qe4ypcexmw==",
             "dependencies": {
                 "eventemitter3": "5.0.1",
                 "mipd": "0.0.7",
@@ -11643,9 +11520,9 @@
             }
         },
         "node_modules/@walletconnect/core": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.13.0.tgz",
-            "integrity": "sha512-blDuZxQenjeXcVJvHxPznTNl6c/2DO4VNrFnus+qHmO6OtT5lZRowdMtlCaCNb1q0OxzgrmBDcTOCbFcCpio/g==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.14.0.tgz",
+            "integrity": "sha512-E/dgBM9q3judXnTfZQ5ILvDpeSdDpabBLsXtYXa3Nyc26cfNplfLJ2nXm9FgtTdhM1nZ7yx4+zDPiXawBRZl2g==",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -11658,8 +11535,8 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.13.0",
-                "@walletconnect/utils": "2.13.0",
+                "@walletconnect/types": "2.14.0",
+                "@walletconnect/utils": "2.14.0",
                 "events": "3.3.0",
                 "isomorphic-unfetch": "3.1.0",
                 "lodash.isequal": "4.5.0",
@@ -11706,19 +11583,19 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/ethereum-provider": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.13.0.tgz",
-            "integrity": "sha512-dnpW8mmLpWl1AZUYGYZpaAfGw1HFkL0WSlhk5xekx3IJJKn4pLacX2QeIOo0iNkzNQxZfux1AK4Grl1DvtzZEA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.14.0.tgz",
+            "integrity": "sha512-Cc2/DCn85VciA10BrsNWFM//3VC1D8yjwrjfUKjGndLPDz0YIdAxTgYZViIlMjE0lzQC/DMvPYEAnGfW0O1Bwg==",
             "dependencies": {
                 "@walletconnect/jsonrpc-http-connection": "1.0.8",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/modal": "2.6.2",
-                "@walletconnect/sign-client": "2.13.0",
-                "@walletconnect/types": "2.13.0",
-                "@walletconnect/universal-provider": "2.13.0",
-                "@walletconnect/utils": "2.13.0",
+                "@walletconnect/sign-client": "2.14.0",
+                "@walletconnect/types": "2.14.0",
+                "@walletconnect/universal-provider": "2.14.0",
+                "@walletconnect/utils": "2.14.0",
                 "events": "3.3.0"
             }
         },
@@ -11887,18 +11764,18 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/sign-client": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.13.0.tgz",
-            "integrity": "sha512-En7KSvNUlQFx20IsYGsFgkNJ2lpvDvRsSFOT5PTdGskwCkUfOpB33SQJ6nCrN19gyoKPNvWg80Cy6MJI0TjNYA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.14.0.tgz",
+            "integrity": "sha512-UrB3S3eLjPYfBLCN3WJ5u7+WcZ8kFMe/QIDqLf76Jk6TaLwkSUy563LvnSw4KW/kA+/cY1KBSdUDfX1tzYJJXg==",
             "dependencies": {
-                "@walletconnect/core": "2.13.0",
+                "@walletconnect/core": "2.14.0",
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.13.0",
-                "@walletconnect/utils": "2.13.0",
+                "@walletconnect/types": "2.14.0",
+                "@walletconnect/utils": "2.14.0",
                 "events": "3.3.0"
             }
         },
@@ -11916,9 +11793,9 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/types": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.13.0.tgz",
-            "integrity": "sha512-MWaVT0FkZwzYbD3tvk8F+2qpPlz1LUSWHuqbINUtMXnSzJtXN49Y99fR7FuBhNFtDalfuWsEK17GrNA+KnAsPQ==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.14.0.tgz",
+            "integrity": "sha512-vevMi4jZLJ55vLuFOicQFmBBbLyb+S0sZS4IsaBdZkQflfGIq34HkN13c/KPl4Ye0aoR4/cUcUSitmGIzEQM5g==",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
@@ -11947,25 +11824,25 @@
             }
         },
         "node_modules/@walletconnect/universal-provider": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.13.0.tgz",
-            "integrity": "sha512-B5QvO8pnk5Bqn4aIt0OukGEQn2Auk9VbHfhQb9cGwgmSCd1GlprX/Qblu4gyT5+TjHMb1Gz5UssUaZWTWbDhBg==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.14.0.tgz",
+            "integrity": "sha512-Mr8uoTmD6H0+Hh+3gxBu4l3T2uP/nNPR02sVtwEujNum++F727mMk+ifPRIpkVo21V/bvXFEy8sHTs5hqyq5iA==",
             "dependencies": {
                 "@walletconnect/jsonrpc-http-connection": "1.0.8",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/sign-client": "2.13.0",
-                "@walletconnect/types": "2.13.0",
-                "@walletconnect/utils": "2.13.0",
+                "@walletconnect/sign-client": "2.14.0",
+                "@walletconnect/types": "2.14.0",
+                "@walletconnect/utils": "2.14.0",
                 "events": "3.3.0"
             }
         },
         "node_modules/@walletconnect/utils": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.13.0.tgz",
-            "integrity": "sha512-q1eDCsRHj5iLe7fF8RroGoPZpdo2CYMZzQSrw1iqL+2+GOeqapxxuJ1vaJkmDUkwgklfB22ufqG6KQnz78sD4w==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.14.0.tgz",
+            "integrity": "sha512-vRVomYQEtEAyCK2c5bzzEvtgxaGGITF8mWuIL+WYSAMyEJLY97mirP2urDucNwcUczwxUgI+no9RiNFbUHreQQ==",
             "dependencies": {
                 "@stablelib/chacha20poly1305": "1.0.1",
                 "@stablelib/hkdf": "1.0.1",
@@ -11975,7 +11852,7 @@
                 "@walletconnect/relay-api": "1.0.10",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.13.0",
+                "@walletconnect/types": "2.14.0",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
@@ -14652,9 +14529,9 @@
             }
         },
         "node_modules/cookie-es": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.1.0.tgz",
-            "integrity": "sha512-L2rLOcK0wzWSfSDA33YR+PUHDG10a8px7rUHKWbGLP4YfbsMed2KFUw5fczvDPbT98DDe3LEzviswl810apTEw=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+            "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
         },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
@@ -16345,9 +16222,9 @@
             }
         },
         "node_modules/elliptic": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+            "version": "6.5.6",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
+            "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -17748,9 +17625,9 @@
             "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-            "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
             "funding": [
                 {
                     "type": "github",
@@ -19657,9 +19534,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "23.12.1",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.12.1.tgz",
-            "integrity": "sha512-l4y291ZGRgUhKuqVSiqyuU2DDzxKStlIWSaoNBR4grYmh0X+pRYbFpTMs3CnJ5ECKbOI8sQcJ3PbTUfLgPRaMA==",
+            "version": "23.11.5",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
+            "integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
             "funding": [
                 {
                     "type": "individual",
@@ -22748,9 +22625,9 @@
             }
         },
         "node_modules/metro": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.9.tgz",
-            "integrity": "sha512-Bc57Xf3GO2Xe4UWQsBj/oW6YfLPABEu8jfDVDiNmJvoQW4CO34oDPuYKe4KlXzXhcuNsqOtSxpbjCRRVjhhREg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.10.tgz",
+            "integrity": "sha512-FDPi0X7wpafmDREXe1lgg3WzETxtXh6Kpq8+IwsG35R2tMyp2kFIqDdshdohuvDt1J/qDARcEPq7V/jElTb1kA==",
             "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
@@ -22767,34 +22644,34 @@
                 "debug": "^2.2.0",
                 "denodeify": "^1.2.1",
                 "error-stack-parser": "^2.0.6",
+                "flow-enums-runtime": "^0.0.6",
                 "graceful-fs": "^4.2.4",
-                "hermes-parser": "0.20.1",
+                "hermes-parser": "0.23.0",
                 "image-size": "^1.0.2",
                 "invariant": "^2.2.4",
                 "jest-worker": "^29.6.3",
                 "jsc-safe-url": "^0.2.2",
                 "lodash.throttle": "^4.1.1",
-                "metro-babel-transformer": "0.80.9",
-                "metro-cache": "0.80.9",
-                "metro-cache-key": "0.80.9",
-                "metro-config": "0.80.9",
-                "metro-core": "0.80.9",
-                "metro-file-map": "0.80.9",
-                "metro-resolver": "0.80.9",
-                "metro-runtime": "0.80.9",
-                "metro-source-map": "0.80.9",
-                "metro-symbolicate": "0.80.9",
-                "metro-transform-plugins": "0.80.9",
-                "metro-transform-worker": "0.80.9",
+                "metro-babel-transformer": "0.80.10",
+                "metro-cache": "0.80.10",
+                "metro-cache-key": "0.80.10",
+                "metro-config": "0.80.10",
+                "metro-core": "0.80.10",
+                "metro-file-map": "0.80.10",
+                "metro-resolver": "0.80.10",
+                "metro-runtime": "0.80.10",
+                "metro-source-map": "0.80.10",
+                "metro-symbolicate": "0.80.10",
+                "metro-transform-plugins": "0.80.10",
+                "metro-transform-worker": "0.80.10",
                 "mime-types": "^2.1.27",
                 "node-fetch": "^2.2.0",
                 "nullthrows": "^1.1.1",
-                "rimraf": "^3.0.2",
                 "serialize-error": "^2.1.0",
                 "source-map": "^0.5.6",
                 "strip-ansi": "^6.0.0",
                 "throat": "^5.0.0",
-                "ws": "^7.5.1",
+                "ws": "^7.5.10",
                 "yargs": "^17.6.2"
             },
             "bin": {
@@ -22805,13 +22682,14 @@
             }
         },
         "node_modules/metro-babel-transformer": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.9.tgz",
-            "integrity": "sha512-d76BSm64KZam1nifRZlNJmtwIgAeZhZG3fi3K+EmPOlrR8rDtBxQHDSN3fSGeNB9CirdTyabTMQCkCup6BXFSQ==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.10.tgz",
+            "integrity": "sha512-GXHueUzgzcazfzORDxDzWS9jVVRV6u+cR6TGvHOfGdfLzJCj7/D0PretLfyq+MwN20twHxLW+BUXkoaB8sCQBg==",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.0",
-                "hermes-parser": "0.20.1",
+                "flow-enums-runtime": "^0.0.6",
+                "hermes-parser": "0.23.0",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -22819,55 +22697,60 @@
             }
         },
         "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-            "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.0.tgz",
+            "integrity": "sha512-Rkp0PNLGpORw4ktsttkVbpYJbrYKS3hAnkxu8D9nvQi6LvSbuPa+tYw/t2u3Gjc35lYd/k95YkjqyTcN4zspag==",
             "peer": true
         },
         "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-            "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.0.tgz",
+            "integrity": "sha512-xLwM4ylfHGwrm+2qXfO1JT/fnqEDGSnpS/9hQ4VLtqTexSviu2ZpBgz07U8jVtndq67qdb/ps0qvaWDZ3fkTyg==",
             "peer": true,
             "dependencies": {
-                "hermes-estree": "0.20.1"
+                "hermes-estree": "0.23.0"
             }
         },
         "node_modules/metro-cache": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.9.tgz",
-            "integrity": "sha512-ujEdSI43QwI+Dj2xuNax8LMo8UgKuXJEdxJkzGPU6iIx42nYa1byQ+aADv/iPh5sh5a//h5FopraW5voXSgm2w==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.10.tgz",
+            "integrity": "sha512-8CBtDJwMguIE5RvV3PU1QtxUG8oSSX54mIuAbRZmcQ0MYiOl9JdrMd4JCBvIyhiZLoSStph425SMyCSnjtJsdA==",
             "peer": true,
             "dependencies": {
-                "metro-core": "0.80.9",
-                "rimraf": "^3.0.2"
+                "exponential-backoff": "^3.1.1",
+                "flow-enums-runtime": "^0.0.6",
+                "metro-core": "0.80.10"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/metro-cache-key": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.9.tgz",
-            "integrity": "sha512-hRcYGhEiWIdM87hU0fBlcGr+tHDEAT+7LYNCW89p5JhErFt/QaAkVx4fb5bW3YtXGv5BTV7AspWPERoIb99CXg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.10.tgz",
+            "integrity": "sha512-57qBhO3zQfoU/hP4ZlLW5hVej2jVfBX6B4NcSfMj4LgDPL3YknWg80IJBxzQfjQY/m+fmMLmPy8aUMHzUp/guA==",
             "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/metro-config": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.9.tgz",
-            "integrity": "sha512-28wW7CqS3eJrunRGnsibWldqgwRP9ywBEf7kg+uzUHkSFJNKPM1K3UNSngHmH0EZjomizqQA2Zi6/y6VdZMolg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.10.tgz",
+            "integrity": "sha512-0GYAw0LkmGbmA81FepKQepL1KU/85Cyv7sAiWm6QWeV6AcVCpsKg6jGLqGHJ0LLPL60rWzA4TV1DQAlzdJAEtA==",
             "peer": true,
             "dependencies": {
                 "connect": "^3.6.5",
                 "cosmiconfig": "^5.0.5",
+                "flow-enums-runtime": "^0.0.6",
                 "jest-validate": "^29.6.3",
-                "metro": "0.80.9",
-                "metro-cache": "0.80.9",
-                "metro-core": "0.80.9",
-                "metro-runtime": "0.80.9"
+                "metro": "0.80.10",
+                "metro-cache": "0.80.10",
+                "metro-core": "0.80.10",
+                "metro-runtime": "0.80.10"
             },
             "engines": {
                 "node": ">=18"
@@ -22952,27 +22835,29 @@
             "peer": true
         },
         "node_modules/metro-core": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.9.tgz",
-            "integrity": "sha512-tbltWQn+XTdULkGdzHIxlxk4SdnKxttvQQV3wpqqFbHDteR4gwCyTR2RyYJvxgU7HELfHtrVbqgqAdlPByUSbg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.10.tgz",
+            "integrity": "sha512-nwBB6HbpGlNsZMuzxVqxqGIOsn5F3JKpsp8PziS7Z4mV8a/jA1d44mVOgYmDa2q5WlH5iJfRIIhdz24XRNDlLA==",
             "peer": true,
             "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
                 "lodash.throttle": "^4.1.1",
-                "metro-resolver": "0.80.9"
+                "metro-resolver": "0.80.10"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/metro-file-map": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.9.tgz",
-            "integrity": "sha512-sBUjVtQMHagItJH/wGU9sn3k2u0nrCl0CdR4SFMO1tksXLKbkigyQx4cbpcyPVOAmGTVuy3jyvBlELaGCAhplQ==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.10.tgz",
+            "integrity": "sha512-ytsUq8coneaN7ZCVk1IogojcGhLIbzWyiI2dNmw2nnBgV/0A+M5WaTTgZ6dJEz3dzjObPryDnkqWPvIGLCPtiw==",
             "peer": true,
             "dependencies": {
                 "anymatch": "^3.0.3",
                 "debug": "^2.2.0",
                 "fb-watchman": "^2.0.0",
+                "flow-enums-runtime": "^0.0.6",
                 "graceful-fs": "^4.2.4",
                 "invariant": "^2.2.4",
                 "jest-worker": "^29.6.3",
@@ -23004,11 +22889,12 @@
             "peer": true
         },
         "node_modules/metro-minify-terser": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.9.tgz",
-            "integrity": "sha512-FEeCeFbkvvPuhjixZ1FYrXtO0araTpV6UbcnGgDUpH7s7eR5FG/PiJz3TsuuPP/HwCK19cZtQydcA2QrCw446A==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.10.tgz",
+            "integrity": "sha512-Xyv9pEYpOsAerrld7cSLIcnCCpv8ItwysOmTA+AKf1q4KyE9cxrH2O2SA0FzMCkPzwxzBWmXwHUr+A89BpEM6g==",
             "peer": true,
             "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
                 "terser": "^5.15.0"
             },
             "engines": {
@@ -23016,38 +22902,43 @@
             }
         },
         "node_modules/metro-resolver": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.9.tgz",
-            "integrity": "sha512-wAPIjkN59BQN6gocVsAvvpZ1+LQkkqUaswlT++cJafE/e54GoVkMNCmrR4BsgQHr9DknZ5Um/nKueeN7kaEz9w==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.10.tgz",
+            "integrity": "sha512-EYC5CL7f+bSzrqdk1bylKqFNGabfiI5PDctxoPx70jFt89Jz+ThcOscENog8Jb4LEQFG6GkOYlwmPpsi7kx3QA==",
             "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/metro-runtime": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.9.tgz",
-            "integrity": "sha512-8PTVIgrVcyU+X/rVCy/9yxNlvXsBCk5JwwkbAm/Dm+Abo6NBGtNjWF0M1Xo/NWCb4phamNWcD7cHdR91HhbJvg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.10.tgz",
+            "integrity": "sha512-Xh0N589ZmSIgJYAM+oYwlzTXEHfASZac9TYPCNbvjNTn0EHKqpoJ/+Im5G3MZT4oZzYv4YnvzRtjqS5k0tK94A==",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.0.0"
+                "@babel/runtime": "^7.0.0",
+                "flow-enums-runtime": "^0.0.6"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/metro-source-map": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.9.tgz",
-            "integrity": "sha512-RMn+XS4VTJIwMPOUSj61xlxgBvPeY4G6s5uIn6kt6HB6A/k9ekhr65UkkDD7WzHYs3a9o869qU8tvOZvqeQzgw==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.10.tgz",
+            "integrity": "sha512-EyZswqJW8Uukv/HcQr6K19vkMXW1nzHAZPWJSEyJFKIbgp708QfRZ6vnZGmrtFxeJEaFdNup4bGnu8/mIOYlyA==",
             "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.20.0",
                 "@babel/types": "^7.20.0",
+                "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-symbolicate": "0.80.9",
+                "metro-symbolicate": "0.80.10",
                 "nullthrows": "^1.1.1",
-                "ob1": "0.80.9",
+                "ob1": "0.80.10",
                 "source-map": "^0.5.6",
                 "vlq": "^1.0.0"
             },
@@ -23065,13 +22956,14 @@
             }
         },
         "node_modules/metro-symbolicate": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.9.tgz",
-            "integrity": "sha512-Ykae12rdqSs98hg41RKEToojuIW85wNdmSe/eHUgMkzbvCFNVgcC0w3dKZEhSsqQOXapXRlLtHkaHLil0UD/EA==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.10.tgz",
+            "integrity": "sha512-qAoVUoSxpfZ2DwZV7IdnQGXCSsf2cAUExUcZyuCqGlY5kaWBb0mx2BL/xbMFDJ4wBp3sVvSBPtK/rt4J7a0xBA==",
             "peer": true,
             "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-source-map": "0.80.9",
+                "metro-source-map": "0.80.10",
                 "nullthrows": "^1.1.1",
                 "source-map": "^0.5.6",
                 "through2": "^2.0.1",
@@ -23104,15 +22996,16 @@
             }
         },
         "node_modules/metro-transform-plugins": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.9.tgz",
-            "integrity": "sha512-UlDk/uc8UdfLNJhPbF3tvwajyuuygBcyp+yBuS/q0z3QSuN/EbLllY3rK8OTD9n4h00qZ/qgxGv/lMFJkwP4vg==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.10.tgz",
+            "integrity": "sha512-leAx9gtA+2MHLsCeWK6XTLBbv2fBnNFu/QiYhWzMq8HsOAP4u1xQAU0tSgPs8+1vYO34Plyn79xTLUtQCRSSUQ==",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.0",
                 "@babel/generator": "^7.20.0",
                 "@babel/template": "^7.0.0",
                 "@babel/traverse": "^7.20.0",
+                "flow-enums-runtime": "^0.0.6",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -23120,22 +23013,23 @@
             }
         },
         "node_modules/metro-transform-worker": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.9.tgz",
-            "integrity": "sha512-c/IrzMUVnI0hSVVit4TXzt3A1GiUltGVlzCmLJWxNrBGHGrJhvgePj38+GXl1Xf4Fd4vx6qLUkKMQ3ux73bFLQ==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.10.tgz",
+            "integrity": "sha512-zNfNLD8Rz99U+JdOTqtF2o7iTjcDMMYdVS90z6+81Tzd2D0lDWVpls7R1hadS6xwM+ymgXFQTjM6V6wFoZaC0g==",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.0",
                 "@babel/generator": "^7.20.0",
                 "@babel/parser": "^7.20.0",
                 "@babel/types": "^7.20.0",
-                "metro": "0.80.9",
-                "metro-babel-transformer": "0.80.9",
-                "metro-cache": "0.80.9",
-                "metro-cache-key": "0.80.9",
-                "metro-minify-terser": "0.80.9",
-                "metro-source-map": "0.80.9",
-                "metro-transform-plugins": "0.80.9",
+                "flow-enums-runtime": "^0.0.6",
+                "metro": "0.80.10",
+                "metro-babel-transformer": "0.80.10",
+                "metro-cache": "0.80.10",
+                "metro-cache-key": "0.80.10",
+                "metro-minify-terser": "0.80.10",
+                "metro-source-map": "0.80.10",
+                "metro-transform-plugins": "0.80.10",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -23158,18 +23052,18 @@
             }
         },
         "node_modules/metro/node_modules/hermes-estree": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-            "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.0.tgz",
+            "integrity": "sha512-Rkp0PNLGpORw4ktsttkVbpYJbrYKS3hAnkxu8D9nvQi6LvSbuPa+tYw/t2u3Gjc35lYd/k95YkjqyTcN4zspag==",
             "peer": true
         },
         "node_modules/metro/node_modules/hermes-parser": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-            "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.0.tgz",
+            "integrity": "sha512-xLwM4ylfHGwrm+2qXfO1JT/fnqEDGSnpS/9hQ4VLtqTexSviu2ZpBgz07U8jVtndq67qdb/ps0qvaWDZ3fkTyg==",
             "peer": true,
             "dependencies": {
-                "hermes-estree": "0.20.1"
+                "hermes-estree": "0.23.0"
             }
         },
         "node_modules/metro/node_modules/ms": {
@@ -24045,6 +23939,7 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui": {
             "version": "8.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24061,6 +23956,7 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
             "version": "6.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24072,11 +23968,13 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
             "version": "9.2.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24093,6 +23991,7 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
             "version": "7.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24107,11 +24006,13 @@
         },
         "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/agent": {
             "version": "2.2.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24127,6 +24028,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
             "version": "7.5.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24175,6 +24077,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/config": {
             "version": "8.3.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24193,6 +24096,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/fs": {
             "version": "3.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24204,6 +24108,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/git": {
             "version": "5.0.8",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24223,6 +24128,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
             "version": "2.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24238,6 +24144,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
             "version": "3.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24252,6 +24159,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
             "version": "7.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24267,6 +24175,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/name-from-folder": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24275,6 +24184,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/node-gyp": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24283,6 +24193,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
             "version": "5.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24300,6 +24211,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/promise-spawn": {
             "version": "7.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24311,6 +24223,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/query": {
             "version": "3.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24322,6 +24235,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/redact": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24330,6 +24244,7 @@
         },
         "node_modules/npm/node_modules/@npmcli/run-script": {
             "version": "8.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24346,14 +24261,17 @@
         },
         "node_modules/npm/node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/npm/node_modules/@sigstore/bundle": {
             "version": "2.3.2",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -24365,6 +24283,7 @@
         },
         "node_modules/npm/node_modules/@sigstore/core": {
             "version": "1.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -24373,6 +24292,7 @@
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
             "version": "0.3.2",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -24381,6 +24301,7 @@
         },
         "node_modules/npm/node_modules/@sigstore/sign": {
             "version": "2.3.2",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -24397,6 +24318,7 @@
         },
         "node_modules/npm/node_modules/@sigstore/tuf": {
             "version": "2.3.4",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -24409,6 +24331,7 @@
         },
         "node_modules/npm/node_modules/@sigstore/verify": {
             "version": "1.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -24422,6 +24345,7 @@
         },
         "node_modules/npm/node_modules/@tufjs/canonical-json": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24430,6 +24354,7 @@
         },
         "node_modules/npm/node_modules/@tufjs/models": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24442,6 +24367,7 @@
         },
         "node_modules/npm/node_modules/abbrev": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24450,6 +24376,7 @@
         },
         "node_modules/npm/node_modules/agent-base": {
             "version": "7.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24461,6 +24388,7 @@
         },
         "node_modules/npm/node_modules/aggregate-error": {
             "version": "3.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24473,6 +24401,7 @@
         },
         "node_modules/npm/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24481,6 +24410,7 @@
         },
         "node_modules/npm/node_modules/ansi-styles": {
             "version": "6.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24492,21 +24422,25 @@
         },
         "node_modules/npm/node_modules/aproba": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/balanced-match": {
             "version": "1.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
             "version": "4.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24521,6 +24455,7 @@
         },
         "node_modules/npm/node_modules/binary-extensions": {
             "version": "2.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24532,6 +24467,7 @@
         },
         "node_modules/npm/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24540,6 +24476,7 @@
         },
         "node_modules/npm/node_modules/cacache": {
             "version": "18.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24562,6 +24499,7 @@
         },
         "node_modules/npm/node_modules/chalk": {
             "version": "5.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24573,6 +24511,7 @@
         },
         "node_modules/npm/node_modules/chownr": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24581,6 +24520,7 @@
         },
         "node_modules/npm/node_modules/ci-info": {
             "version": "4.0.0",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -24595,6 +24535,7 @@
         },
         "node_modules/npm/node_modules/cidr-regex": {
             "version": "4.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -24606,6 +24547,7 @@
         },
         "node_modules/npm/node_modules/clean-stack": {
             "version": "2.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24614,6 +24556,7 @@
         },
         "node_modules/npm/node_modules/cli-columns": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24626,6 +24569,7 @@
         },
         "node_modules/npm/node_modules/cmd-shim": {
             "version": "6.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24634,6 +24578,7 @@
         },
         "node_modules/npm/node_modules/color-convert": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24645,16 +24590,19 @@
         },
         "node_modules/npm/node_modules/color-name": {
             "version": "1.1.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/common-ancestor-path": {
             "version": "1.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cross-spawn": {
             "version": "7.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24668,6 +24616,7 @@
         },
         "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24682,6 +24631,7 @@
         },
         "node_modules/npm/node_modules/cssesc": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "bin": {
@@ -24693,6 +24643,7 @@
         },
         "node_modules/npm/node_modules/debug": {
             "version": "4.3.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24709,11 +24660,13 @@
         },
         "node_modules/npm/node_modules/debug/node_modules/ms": {
             "version": "2.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/diff": {
             "version": "5.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -24722,24 +24675,29 @@
         },
         "node_modules/npm/node_modules/eastasianwidth": {
             "version": "0.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/emoji-regex": {
             "version": "8.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/encoding": {
             "version": "0.1.13",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
             }
         },
         "node_modules/npm/node_modules/env-paths": {
             "version": "2.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24748,16 +24706,19 @@
         },
         "node_modules/npm/node_modules/err-code": {
             "version": "2.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/exponential-backoff": {
             "version": "3.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0"
         },
         "node_modules/npm/node_modules/fastest-levenshtein": {
             "version": "1.0.16",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24766,6 +24727,7 @@
         },
         "node_modules/npm/node_modules/foreground-child": {
             "version": "3.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24781,6 +24743,7 @@
         },
         "node_modules/npm/node_modules/fs-minipass": {
             "version": "3.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24792,6 +24755,7 @@
         },
         "node_modules/npm/node_modules/glob": {
             "version": "10.4.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24814,11 +24778,13 @@
         },
         "node_modules/npm/node_modules/graceful-fs": {
             "version": "4.2.11",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "7.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24830,11 +24796,13 @@
         },
         "node_modules/npm/node_modules/http-cache-semantics": {
             "version": "4.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/http-proxy-agent": {
             "version": "7.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24847,6 +24815,7 @@
         },
         "node_modules/npm/node_modules/https-proxy-agent": {
             "version": "7.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24859,8 +24828,10 @@
         },
         "node_modules/npm/node_modules/iconv-lite": {
             "version": "0.6.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -24870,6 +24841,7 @@
         },
         "node_modules/npm/node_modules/ignore-walk": {
             "version": "6.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24881,6 +24853,7 @@
         },
         "node_modules/npm/node_modules/imurmurhash": {
             "version": "0.1.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24889,6 +24862,7 @@
         },
         "node_modules/npm/node_modules/indent-string": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24897,6 +24871,7 @@
         },
         "node_modules/npm/node_modules/ini": {
             "version": "4.1.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -24905,6 +24880,7 @@
         },
         "node_modules/npm/node_modules/init-package-json": {
             "version": "6.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -24922,6 +24898,7 @@
         },
         "node_modules/npm/node_modules/ip-address": {
             "version": "9.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -24934,6 +24911,7 @@
         },
         "node_modules/npm/node_modules/ip-regex": {
             "version": "5.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24945,6 +24923,7 @@
         },
         "node_modules/npm/node_modules/is-cidr": {
             "version": "5.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -24956,6 +24935,7 @@
         },
         "node_modules/npm/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -24964,16 +24944,19 @@
         },
         "node_modules/npm/node_modules/is-lambda": {
             "version": "1.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/isexe": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/jackspeak": {
             "version": "3.4.0",
+            "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -24991,11 +24974,13 @@
         },
         "node_modules/npm/node_modules/jsbn": {
             "version": "1.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
             "version": "3.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25004,6 +24989,7 @@
         },
         "node_modules/npm/node_modules/json-stringify-nice": {
             "version": "1.1.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -25012,6 +24998,7 @@
         },
         "node_modules/npm/node_modules/jsonparse": {
             "version": "1.3.1",
+            "dev": true,
             "engines": [
                 "node >= 0.2.0"
             ],
@@ -25020,16 +25007,19 @@
         },
         "node_modules/npm/node_modules/just-diff": {
             "version": "6.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/just-diff-apply": {
             "version": "5.5.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/libnpmaccess": {
             "version": "8.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25042,6 +25032,7 @@
         },
         "node_modules/npm/node_modules/libnpmdiff": {
             "version": "6.1.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25060,6 +25051,7 @@
         },
         "node_modules/npm/node_modules/libnpmexec": {
             "version": "8.1.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25080,6 +25072,7 @@
         },
         "node_modules/npm/node_modules/libnpmfund": {
             "version": "5.0.12",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25091,6 +25084,7 @@
         },
         "node_modules/npm/node_modules/libnpmhook": {
             "version": "10.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25103,6 +25097,7 @@
         },
         "node_modules/npm/node_modules/libnpmorg": {
             "version": "6.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25115,6 +25110,7 @@
         },
         "node_modules/npm/node_modules/libnpmpack": {
             "version": "7.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25129,6 +25125,7 @@
         },
         "node_modules/npm/node_modules/libnpmpublish": {
             "version": "9.0.9",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25147,6 +25144,7 @@
         },
         "node_modules/npm/node_modules/libnpmsearch": {
             "version": "7.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25158,6 +25156,7 @@
         },
         "node_modules/npm/node_modules/libnpmteam": {
             "version": "6.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25170,6 +25169,7 @@
         },
         "node_modules/npm/node_modules/libnpmversion": {
             "version": "6.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25185,6 +25185,7 @@
         },
         "node_modules/npm/node_modules/lru-cache": {
             "version": "10.2.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25193,6 +25194,7 @@
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
             "version": "13.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25215,6 +25217,7 @@
         },
         "node_modules/npm/node_modules/minimatch": {
             "version": "9.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25229,6 +25232,7 @@
         },
         "node_modules/npm/node_modules/minipass": {
             "version": "7.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25237,6 +25241,7 @@
         },
         "node_modules/npm/node_modules/minipass-collect": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25248,6 +25253,7 @@
         },
         "node_modules/npm/node_modules/minipass-fetch": {
             "version": "3.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25264,6 +25270,7 @@
         },
         "node_modules/npm/node_modules/minipass-flush": {
             "version": "1.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25275,6 +25282,7 @@
         },
         "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25286,6 +25294,7 @@
         },
         "node_modules/npm/node_modules/minipass-pipeline": {
             "version": "1.2.4",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25297,6 +25306,7 @@
         },
         "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25308,6 +25318,7 @@
         },
         "node_modules/npm/node_modules/minipass-sized": {
             "version": "1.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25319,6 +25330,7 @@
         },
         "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25330,6 +25342,7 @@
         },
         "node_modules/npm/node_modules/minizlib": {
             "version": "2.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25342,6 +25355,7 @@
         },
         "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25353,6 +25367,7 @@
         },
         "node_modules/npm/node_modules/mkdirp": {
             "version": "1.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "bin": {
@@ -25364,11 +25379,13 @@
         },
         "node_modules/npm/node_modules/ms": {
             "version": "2.1.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/mute-stream": {
             "version": "1.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25377,6 +25394,7 @@
         },
         "node_modules/npm/node_modules/negotiator": {
             "version": "0.6.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25385,6 +25403,7 @@
         },
         "node_modules/npm/node_modules/node-gyp": {
             "version": "10.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25408,6 +25427,7 @@
         },
         "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25416,6 +25436,7 @@
         },
         "node_modules/npm/node_modules/nopt": {
             "version": "7.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25430,6 +25451,7 @@
         },
         "node_modules/npm/node_modules/normalize-package-data": {
             "version": "6.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -25443,6 +25465,7 @@
         },
         "node_modules/npm/node_modules/npm-audit-report": {
             "version": "5.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25451,6 +25474,7 @@
         },
         "node_modules/npm/node_modules/npm-bundled": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25462,6 +25486,7 @@
         },
         "node_modules/npm/node_modules/npm-install-checks": {
             "version": "6.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -25473,6 +25498,7 @@
         },
         "node_modules/npm/node_modules/npm-normalize-package-bin": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25481,6 +25507,7 @@
         },
         "node_modules/npm/node_modules/npm-package-arg": {
             "version": "11.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25495,6 +25522,7 @@
         },
         "node_modules/npm/node_modules/npm-packlist": {
             "version": "8.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25506,6 +25534,7 @@
         },
         "node_modules/npm/node_modules/npm-pick-manifest": {
             "version": "9.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25520,6 +25549,7 @@
         },
         "node_modules/npm/node_modules/npm-profile": {
             "version": "10.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25532,6 +25562,7 @@
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
             "version": "17.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25550,6 +25581,7 @@
         },
         "node_modules/npm/node_modules/npm-user-validate": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -25558,6 +25590,7 @@
         },
         "node_modules/npm/node_modules/p-map": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25572,11 +25605,13 @@
         },
         "node_modules/npm/node_modules/package-json-from-dist": {
             "version": "1.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/npm/node_modules/pacote": {
             "version": "18.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25607,6 +25642,7 @@
         },
         "node_modules/npm/node_modules/parse-conflict-json": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25620,6 +25656,7 @@
         },
         "node_modules/npm/node_modules/path-key": {
             "version": "3.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25628,6 +25665,7 @@
         },
         "node_modules/npm/node_modules/path-scurry": {
             "version": "1.11.1",
+            "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -25643,6 +25681,7 @@
         },
         "node_modules/npm/node_modules/postcss-selector-parser": {
             "version": "6.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25655,6 +25694,7 @@
         },
         "node_modules/npm/node_modules/proc-log": {
             "version": "4.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25663,6 +25703,7 @@
         },
         "node_modules/npm/node_modules/proggy": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25671,6 +25712,7 @@
         },
         "node_modules/npm/node_modules/promise-all-reject-late": {
             "version": "1.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -25679,6 +25721,7 @@
         },
         "node_modules/npm/node_modules/promise-call-limit": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -25687,11 +25730,13 @@
         },
         "node_modules/npm/node_modules/promise-inflight": {
             "version": "1.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/promise-retry": {
             "version": "2.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25704,6 +25749,7 @@
         },
         "node_modules/npm/node_modules/promzard": {
             "version": "1.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25715,6 +25761,7 @@
         },
         "node_modules/npm/node_modules/qrcode-terminal": {
             "version": "0.12.0",
+            "dev": true,
             "inBundle": true,
             "bin": {
                 "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -25722,6 +25769,7 @@
         },
         "node_modules/npm/node_modules/read": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25733,6 +25781,7 @@
         },
         "node_modules/npm/node_modules/read-cmd-shim": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25741,6 +25790,7 @@
         },
         "node_modules/npm/node_modules/read-package-json-fast": {
             "version": "3.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25753,6 +25803,7 @@
         },
         "node_modules/npm/node_modules/retry": {
             "version": "0.12.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25761,11 +25812,14 @@
         },
         "node_modules/npm/node_modules/safer-buffer": {
             "version": "2.1.2",
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/npm/node_modules/semver": {
             "version": "7.6.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "bin": {
@@ -25777,6 +25831,7 @@
         },
         "node_modules/npm/node_modules/shebang-command": {
             "version": "2.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25788,6 +25843,7 @@
         },
         "node_modules/npm/node_modules/shebang-regex": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25796,6 +25852,7 @@
         },
         "node_modules/npm/node_modules/signal-exit": {
             "version": "4.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -25807,6 +25864,7 @@
         },
         "node_modules/npm/node_modules/sigstore": {
             "version": "2.3.1",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -25823,6 +25881,7 @@
         },
         "node_modules/npm/node_modules/smart-buffer": {
             "version": "4.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25832,6 +25891,7 @@
         },
         "node_modules/npm/node_modules/socks": {
             "version": "2.8.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25845,6 +25905,7 @@
         },
         "node_modules/npm/node_modules/socks-proxy-agent": {
             "version": "8.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25858,6 +25919,7 @@
         },
         "node_modules/npm/node_modules/spdx-correct": {
             "version": "3.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -25867,6 +25929,7 @@
         },
         "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25876,11 +25939,13 @@
         },
         "node_modules/npm/node_modules/spdx-exceptions": {
             "version": "2.5.0",
+            "dev": true,
             "inBundle": true,
             "license": "CC-BY-3.0"
         },
         "node_modules/npm/node_modules/spdx-expression-parse": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25890,16 +25955,19 @@
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
             "version": "3.0.18",
+            "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
         },
         "node_modules/npm/node_modules/sprintf-js": {
             "version": "1.1.3",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ssri": {
             "version": "10.0.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25911,6 +25979,7 @@
         },
         "node_modules/npm/node_modules/string-width": {
             "version": "4.2.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25925,6 +25994,7 @@
         "node_modules/npm/node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25938,6 +26008,7 @@
         },
         "node_modules/npm/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25950,6 +26021,7 @@
         "node_modules/npm/node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -25961,6 +26033,7 @@
         },
         "node_modules/npm/node_modules/supports-color": {
             "version": "9.4.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -25972,6 +26045,7 @@
         },
         "node_modules/npm/node_modules/tar": {
             "version": "6.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25988,6 +26062,7 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
             "version": "2.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -25999,6 +26074,7 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -26010,6 +26086,7 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/minipass": {
             "version": "5.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -26018,16 +26095,19 @@
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tiny-relative-date": {
             "version": "1.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/treeverse": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -26036,6 +26116,7 @@
         },
         "node_modules/npm/node_modules/tuf-js": {
             "version": "2.2.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26049,6 +26130,7 @@
         },
         "node_modules/npm/node_modules/unique-filename": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -26060,6 +26142,7 @@
         },
         "node_modules/npm/node_modules/unique-slug": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -26071,11 +26154,13 @@
         },
         "node_modules/npm/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/validate-npm-package-license": {
             "version": "3.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -26085,6 +26170,7 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26094,6 +26180,7 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
             "version": "5.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -26102,11 +26189,13 @@
         },
         "node_modules/npm/node_modules/walk-up-path": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/which": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -26121,6 +26210,7 @@
         },
         "node_modules/npm/node_modules/which/node_modules/isexe": {
             "version": "3.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -26129,6 +26219,7 @@
         },
         "node_modules/npm/node_modules/wrap-ansi": {
             "version": "8.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26146,6 +26237,7 @@
         "node_modules/npm/node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26162,6 +26254,7 @@
         },
         "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
             "version": "4.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26176,6 +26269,7 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -26187,11 +26281,13 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
             "version": "9.2.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
             "version": "5.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26208,6 +26304,7 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "7.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -26222,6 +26319,7 @@
         },
         "node_modules/npm/node_modules/write-file-atomic": {
             "version": "5.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -26234,6 +26332,7 @@
         },
         "node_modules/npm/node_modules/yallist": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
@@ -26425,10 +26524,13 @@
             }
         },
         "node_modules/ob1": {
-            "version": "0.80.9",
-            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.9.tgz",
-            "integrity": "sha512-v9yOxowkZbxWhKOaaTyLjIm1aLy4ebMNcSn4NYJKOAI/Qv+SkfEfszpLr2GIxsccmb2Y2HA9qtsqiIJ80ucpVA==",
+            "version": "0.80.10",
+            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.10.tgz",
+            "integrity": "sha512-dJHyB0S6JkMorUSfSGcYGkkg9kmq3qDUu3ygZUKIfkr47XOPuG35r2Sk6tbwtHXbdKIXmcMvM8DF2CwgdyaHfQ==",
             "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
             "engines": {
                 "node": ">=18"
             }
@@ -27598,9 +27700,9 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.22.1",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
-            "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
+            "version": "10.23.2",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
+            "integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -28208,11 +28310,11 @@
             }
         },
         "node_modules/react-hook-form": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz",
-            "integrity": "sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==",
+            "version": "7.52.2",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz",
+            "integrity": "sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==",
             "engines": {
-                "node": ">=12.22.0"
+                "node": ">=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -32049,15 +32151,15 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/unenv": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.9.0.tgz",
-            "integrity": "sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+            "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
             "dependencies": {
                 "consola": "^3.2.3",
-                "defu": "^6.1.3",
+                "defu": "^6.1.4",
                 "mime": "^3.0.0",
-                "node-fetch-native": "^1.6.1",
-                "pathe": "^1.1.1"
+                "node-fetch-native": "^1.6.4",
+                "pathe": "^1.1.2"
             }
         },
         "node_modules/unenv/node_modules/mime": {
@@ -32428,6 +32530,14 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/username": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/username/-/username-5.1.0.tgz",
@@ -32654,14 +32764,6 @@
                 "react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/valtio/node_modules/use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/value-or-promise": {
@@ -32934,12 +33036,12 @@
             }
         },
         "node_modules/wagmi": {
-            "version": "2.10.11",
-            "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.10.11.tgz",
-            "integrity": "sha512-0cbyhjB7Ry7DhEuxksdQf3tRVlUQhReVv+/G+Kb3sYV5wJrLvdrHNqGnUFKqbRd5GuZesGJBvypYdS0rv8k2xw==",
+            "version": "2.12.5",
+            "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.12.5.tgz",
+            "integrity": "sha512-+fpSUsVKyGOumguQirtpyMb7dmDP4/ZdwrTqrBc+WZVTwR9S8WdFPParw/BKXVZjF9euJxu1zKsWQSLBeCROfQ==",
             "dependencies": {
-                "@wagmi/connectors": "5.0.23",
-                "@wagmi/core": "2.11.8",
+                "@wagmi/connectors": "5.1.5",
+                "@wagmi/core": "2.13.4",
                 "use-sync-external-store": "1.2.0"
             },
             "funding": {
@@ -32955,14 +33057,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/wagmi/node_modules/use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/walk-up-path": {
@@ -33562,14 +33656,6 @@
                 "react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/zustand/node_modules/use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "xvfb-maybe": "^0.2.1"
     },
     "dependencies": {
-        "@powerhousedao/design-system": "1.0.0-alpha.160",
+        "@powerhousedao/design-system": "1.0.0-alpha.162",
         "@sentry/react": "^7.109.0",
         "@tanstack/react-virtual": "^3.8.1",
         "did-key-creator": "^1.2.0",

--- a/src/components/editor-loader.tsx
+++ b/src/components/editor-loader.tsx
@@ -1,13 +1,13 @@
-import { DefaultEditorLoader } from '@powerhousedao/design-system';
-import { ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useLoadingScreen } from 'src/hooks/useLoadingScreen';
 
-type Props = {
-    customEditorLoader?: ReactNode;
-};
-export function EditorLoader(props: Props) {
-    const { customEditorLoader } = props;
+export function EditorLoader() {
+    const { setShowLoadingScreen } = useLoadingScreen();
 
-    if (customEditorLoader) return <>{customEditorLoader}</>;
+    useEffect(() => {
+        setShowLoadingScreen(true);
+        return () => setShowLoadingScreen(false);
+    }, [setShowLoadingScreen]);
 
-    return <DefaultEditorLoader />;
+    return null;
 }

--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -11,6 +11,7 @@ import {
 import { useAtomValue } from 'jotai';
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useConnectCrypto, useConnectDid } from 'src/hooks/useConnectCrypto';
+import { useLoadingScreen } from 'src/hooks/useLoadingScreen';
 import { TUiNodes } from 'src/hooks/useUiNodes';
 import { useUndoRedoShortcuts } from 'src/hooks/useUndoRedoShortcuts';
 import { useUserPermissions } from 'src/hooks/useUserPermissions';
@@ -57,6 +58,7 @@ export function DocumentEditor(props: EditorProps) {
     const documentModel = useDocumentModel(initialDocument.documentType);
     const editor = useEditor(initialDocument.documentType);
     const theme = useAtomValue(themeAtom);
+    const { setShowLoadingScreen } = useLoadingScreen();
     const [document, _dispatch, error] = useDocumentDispatch(
         documentModel?.reducer,
         initialDocument,
@@ -76,6 +78,10 @@ export function DocumentEditor(props: EditorProps) {
         (document.revision.global > 0 || document.revision.local > 0);
     const canRedo = !!document?.clipboard.length;
     useUndoRedoShortcuts({ undo, redo, canUndo, canRedo });
+
+    if (isLoadingEditor) {
+        setShowLoadingScreen(isLoadingEditor);
+    }
 
     function dispatch(
         action: BaseAction | Action,

--- a/src/hooks/useFeatureFlags/default-config.ts
+++ b/src/hooks/useFeatureFlags/default-config.ts
@@ -9,8 +9,8 @@ const disabledEditors = DISABLED_EDITORS?.split(',');
 
 export interface FeatureFlag {
     defaultDrives?: {
-        url: string;
-        loaded: boolean;
+        url: string; // url of the remote drive
+        loaded: boolean; // whether the drive has been loaded or not
     }[];
     editors: {
         enabledEditors?: '*' | string[];

--- a/src/hooks/useInitialLoadingStatus.ts
+++ b/src/hooks/useInitialLoadingStatus.ts
@@ -1,0 +1,57 @@
+import { atom, useAtom } from 'jotai';
+
+type InitialLoadingStatus =
+    | 'READY' // initial sync for the drive has been finished (either failed or succeeded)
+    | 'LOADING' // remote drive is being loaded but not synced yet
+    | 'SYNCING'; // remote drive is syncing
+
+const DEFAULT_DRIVES_URL = import.meta.env.VITE_DEFAULT_DRIVES_URL || undefined;
+const defaultDrives = DEFAULT_DRIVES_URL ? DEFAULT_DRIVES_URL.split(',') : [];
+
+const defaultInitialState = defaultDrives.map(driveUrl => ({
+    url: driveUrl,
+    initialSyncStatus: 'LOADING' as InitialLoadingStatus,
+}));
+
+const drivesInitialSyncStatusAtom = atom(defaultInitialState);
+
+export const useInitialLoadingStatus = () => {
+    const [initialLoadingStatus, setInitialLoadingStatus] = useAtom(
+        drivesInitialSyncStatusAtom,
+    );
+
+    const setDriveInitialLoadingStatus = (
+        url: string,
+        status: InitialLoadingStatus,
+    ) =>
+        setInitialLoadingStatus(prevState =>
+            prevState.map(drive =>
+                drive.url === url
+                    ? { ...drive, initialSyncStatus: status }
+                    : drive,
+            ),
+        );
+
+    const getDriveInitialLoadingStatus = (driveId?: string) => {
+        if (!driveId) return 'READY';
+
+        const drive = initialLoadingStatus.find(driveStatus => {
+            const parsedUrl = new URL(driveStatus.url);
+            const pathname = parsedUrl.pathname;
+            const driveIdFromUrl = pathname.substring(
+                pathname.lastIndexOf('/') + 1,
+            );
+
+            return driveId === driveIdFromUrl;
+        });
+
+        return drive?.initialSyncStatus || 'READY';
+    };
+
+    return {
+        initialLoadingStatus,
+        setInitialLoadingStatus,
+        setDriveInitialLoadingStatus,
+        getDriveInitialLoadingStatus,
+    };
+};

--- a/src/hooks/useLoadingScreen.ts
+++ b/src/hooks/useLoadingScreen.ts
@@ -1,0 +1,57 @@
+import { atom, useAtom } from 'jotai';
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useInitialLoadingStatus } from './useInitialLoadingStatus';
+
+const showLoadingAtom = atom(false);
+const customLoadingComponent = atom<React.ReactNode | undefined>(undefined);
+
+type RouteParams = {
+    driveId?: string;
+    '*'?: string;
+};
+
+// this is to extend the initial loading screen for a bit to allow
+// set the visibility of the loading screen manually and avoid flickering
+const INITIAL_LOADING_TIMEOUT = 300;
+
+export const useLoadingScreen = () => {
+    const params = useParams<RouteParams>();
+    const { getDriveInitialLoadingStatus } = useInitialLoadingStatus();
+    const driveId = decodeURIComponent(params.driveId || '');
+
+    const loadingStatus = getDriveInitialLoadingStatus(driveId);
+    const timeout = useRef<NodeJS.Timeout | undefined>();
+
+    const [showInitialLoading, setShowInitialLoading] = useState(
+        loadingStatus !== 'READY',
+    );
+    const [showLoading, setShowLoading] = useAtom(showLoadingAtom);
+    const [loadingComponent, setLoadingComponent] = useAtom(
+        customLoadingComponent,
+    );
+
+    useEffect(() => {
+        if (loadingStatus === 'READY') {
+            timeout.current = setTimeout(() => {
+                setShowInitialLoading(false);
+            }, INITIAL_LOADING_TIMEOUT);
+        }
+
+        return () => clearTimeout(timeout.current);
+    }, [loadingStatus]);
+
+    const setShowLoadingScreen = (show: boolean) => {
+        clearTimeout(timeout.current);
+        setShowLoading(show);
+    };
+
+    const showLoadingScreen = showInitialLoading || showLoading;
+
+    return {
+        loadingComponent,
+        showLoadingScreen,
+        setLoadingComponent,
+        setShowLoadingScreen,
+    };
+};

--- a/src/hooks/useNodeNavigation.ts
+++ b/src/hooks/useNodeNavigation.ts
@@ -7,6 +7,7 @@ import {
 } from '@powerhousedao/design-system';
 import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useInitialLoadingStatus } from './useInitialLoadingStatus';
 
 type RouteParams = {
     driveId?: string;
@@ -32,7 +33,7 @@ function buildPathname(selectedNodePath: UiNode[]) {
 }
 
 function makeDriveNodeUrlComponent(driveNode: UiDriveNode) {
-    const component = driveNode.slug || driveNode.name || driveNode.id;
+    const component = driveNode.slug || driveNode.id || driveNode.name;
 
     return `/d/${encodeURIComponent(component)}`;
 }
@@ -41,7 +42,9 @@ function getSelectedNodeFromPathname(
     driveNodes: (UiDriveNode | null)[],
     driveIdFromPathname: string | undefined,
     nodeNamesFromPathname: string | undefined,
+    initialLoading: boolean,
 ) {
+    if (initialLoading) return null;
     if (!driveIdFromPathname) {
         return driveNodes[0];
     }
@@ -89,12 +92,18 @@ export const useNodeNavigation = () => {
     const params = useParams<RouteParams>();
     const { driveNodes, selectedNode, selectedNodePath, setSelectedNode } =
         useUiNodesContext();
+    const { getDriveInitialLoadingStatus } = useInitialLoadingStatus();
     const driveIdFromPathname = params.driveId;
     const nodeNamesFromPathname = params['*'];
+
+    const initialLoading =
+        getDriveInitialLoadingStatus(driveIdFromPathname) !== 'READY';
+
     const selectedNodeFromPathname = getSelectedNodeFromPathname(
         driveNodes,
         driveIdFromPathname,
         nodeNamesFromPathname,
+        initialLoading,
     );
     const selectedNodePathname = buildPathname(selectedNodePath);
 
@@ -108,10 +117,16 @@ export const useNodeNavigation = () => {
     // on first load, set the selected node from the pathname
     // defaults to setting the first drive node if no drive node is found
     useEffect(() => {
+        if (initialLoading) return;
         if (selectedNode || !selectedNodeFromPathname) return;
 
         setSelectedNode(selectedNodeFromPathname);
-    }, [selectedNode, selectedNodeFromPathname, setSelectedNode]);
+    }, [
+        selectedNode,
+        selectedNodeFromPathname,
+        setSelectedNode,
+        initialLoading,
+    ]);
 
     // respond to changes in the url (browser back and forward buttons)
     // update the selected node accordingly
@@ -120,6 +135,7 @@ export const useNodeNavigation = () => {
             driveNodes,
             driveIdFromPathname,
             nodeNamesFromPathname,
+            initialLoading,
         );
 
         if (!selectedNodeFromPathname) return;
@@ -130,5 +146,6 @@ export const useNodeNavigation = () => {
         driveIdFromPathname,
         nodeNamesFromPathname,
         setSelectedNode,
+        initialLoading,
     ]);
 };

--- a/src/hooks/useUiNodes.ts
+++ b/src/hooks/useUiNodes.ts
@@ -162,7 +162,8 @@ export function useUiNodes() {
 
     const makeUiDriveNodes = useCallback(
         async (documentDrives: DocumentDriveDocument[]) => {
-            return Promise.all(documentDrives.map(makeUiDriveNode));
+            const drives = Promise.all(documentDrives.map(makeUiDriveNode));
+            return drives;
         },
         [makeUiDriveNode],
     );

--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, FILE } from '@powerhousedao/design-system';
+import { Breadcrumbs, FILE, LoadingScreen } from '@powerhousedao/design-system';
 import { Document, DocumentModel, Operation } from 'document-model/document';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import FolderView from 'src/components/folder-view';
 import { useModal } from 'src/components/modal';
 import { SearchBar } from 'src/components/search-bar';
 import { useConnectConfig } from 'src/hooks/useConnectConfig';
+import { useLoadingScreen } from 'src/hooks/useLoadingScreen';
 import { useNodeNavigation } from 'src/hooks/useNodeNavigation';
 import { useUiNodes } from 'src/hooks/useUiNodes';
 import { usePreloadEditor } from 'src/store/editor';
@@ -44,6 +45,8 @@ const Content = () => {
     } = useUiNodes();
     const { showModal } = useModal();
     const preloadEditor = usePreloadEditor();
+    const { showLoadingScreen, loadingComponent } = useLoadingScreen();
+
     useNodeNavigation();
 
     // preload document editors
@@ -151,6 +154,11 @@ const Content = () => {
             className="flex h-full flex-col overflow-auto bg-gray-100 p-6"
             id="content-view"
         >
+            <LoadingScreen
+                size={150}
+                showLoadingScreen={showLoadingScreen}
+                loadingComponent={loadingComponent}
+            />
             {selectedDocument ? (
                 <div className="flex-1 rounded-2xl bg-gray-50 p-4">
                     <DocumentEditor


### PR DESCRIPTION
## Description:

- Implemented loading screen

### Loading Screen has been implemented with the following behavior:

- If the user accesses a base URL with no drive, file, or folder selected, no loading screen is displayed, and the default drive is selected.
- If the user accesses a URL with a drive, file, or folder selected, the loading screen is displayed until the selected drive finishes the initial sync.
- If the user tries to visit a URL with a drive that is not part of the default drives, no loading screen is displayed, and the default drive is selected instead.

![2024-08-13 13 52 36](https://github.com/user-attachments/assets/4f131669-8549-46d5-9da0-9d903111cee3)

![2024-08-13 13 53 03](https://github.com/user-attachments/assets/4a76ca99-c2a7-4b94-82a3-10c0ef58e1f3)


How it works:

`useInitialLoadingStatus` hook is used to manage the initial sync status of the drives (default remote drives)

it starts by defaulting the initial sync status of the drives to `LOADING` (`LOADING` means that the drive is being loaded but not synced yet).
later, `useLoadDefaultDrives` runs and updates the initial sync status for the drives based on the result of the drive addition:
- if the drive is already added, it sets the initial sync status for the drive as `READY` (`READY` means that the initial sync of the drive has finished, either successfully or with error)
- if the drive is added successfully, it sets the initial sync status for the drive as `SYNCING` (`SYNCING` means that the drive entered the sync process)
- if the drive fails to load, it sets the initial sync status for the drive as `READY` (`READY` means that the initial sync of the drive has finished, either successfully or with error)

inside `useLoadInitialData` hook, we subscribe to the sync status changes of the drives
if we receive a sync status update !== `SYNCING`, we set the initialSyncStatus for the drive as `READY`