### PR TITLE
feat: added detach strategy for old drives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@powerhousedao/connect",
-    "version": "1.0.0-dev.129",
+    "version": "1.0.0-dev.131",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@powerhousedao/connect",
-            "version": "1.0.0-dev.129",
+            "version": "1.0.0-dev.131",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "express": "^4.21.0"
@@ -43,7 +43,7 @@
                 "autoprefixer": "^10.4.14",
                 "cypress": "^13.11.0",
                 "did-key-creator": "^1.2.0",
-                "document-drive": "^1.0.0-alpha.98",
+                "document-drive": "1.0.0-alpha.99",
                 "document-model": "^1.8.0",
                 "document-model-libs": "^1.89.0",
                 "electron": "30.0.0",
@@ -6808,6 +6808,7 @@
         },
         "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
             "version": "1.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -15986,9 +15987,9 @@
             }
         },
         "node_modules/document-drive": {
-            "version": "1.0.0-alpha.98",
-            "resolved": "https://registry.npmjs.org/document-drive/-/document-drive-1.0.0-alpha.98.tgz",
-            "integrity": "sha512-Btim+7JDKklx6M3lQsx0ZawO9ieA7mjm+BICFJ5dWruyyMqbeKoFXZRJHStIZ88Kou4JBDSk5C82qYaFfwo/7A==",
+            "version": "1.0.0-alpha.99",
+            "resolved": "https://registry.npmjs.org/document-drive/-/document-drive-1.0.0-alpha.99.tgz",
+            "integrity": "sha512-7wold5cpCohorixcuLbRe7Fkm9kVOQ49B3XpcHUJa2WWNyFk2k1CKMBuCFhBt20InqfH1hG3uDCg9tZqvqzwYQ==",
             "dev": true,
             "dependencies": {
                 "change-case": "^5.4.4",
@@ -16009,7 +16010,7 @@
             },
             "peerDependencies": {
                 "document-model": "^1.8.0",
-                "document-model-libs": "^1.57.0"
+                "document-model-libs": "^1.90.1"
             }
         },
         "node_modules/document-model": {
@@ -16029,9 +16030,9 @@
             }
         },
         "node_modules/document-model-libs": {
-            "version": "1.89.0",
-            "resolved": "https://registry.npmjs.org/document-model-libs/-/document-model-libs-1.89.0.tgz",
-            "integrity": "sha512-Kjp7hufpyMKispLEfH2ThyhfxjwOKmgpnPF8vH+KP9GAi4u98LDxQZ/dMvZIf1ox6zOZhPXstvgvxtnmlD7LEg==",
+            "version": "1.90.1",
+            "resolved": "https://registry.npmjs.org/document-model-libs/-/document-model-libs-1.90.1.tgz",
+            "integrity": "sha512-iASm00wZ8aVRk2AWN9AsB7sSKIy/kfJj/9NowYV1IHPg1UbcT2N7PpXqIDqMNUqf/0NknBNQrqCytYtAD5yTcg==",
             "dev": true,
             "dependencies": {
                 "@acaldas/graphql-codegen-typescript-validation-schema": "^0.12.3",
@@ -16044,22 +16045,11 @@
                 "deep-object-diff": "^1.1.9",
                 "jsonc-parser": "^3.2.1",
                 "jszip": "^3.10.1",
-                "mathjs": "^13.0.0",
-                "tailwind-merge": "^2.2.1"
+                "mathjs": "^13.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
-            }
-        },
-        "node_modules/document-model-libs/node_modules/tailwind-merge": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
-            "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/dcastil"
             }
         },
         "node_modules/dom-accessibility-api": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "autoprefixer": "^10.4.14",
         "cypress": "^13.11.0",
         "did-key-creator": "^1.2.0",
-        "document-drive": "^1.0.0-alpha.98",
+        "document-drive": "1.0.0-alpha.99",
         "document-model": "^1.8.0",
         "document-model-libs": "^1.89.0",
         "electron": "30.0.0",

--- a/src/utils/reactor.ts
+++ b/src/utils/reactor.ts
@@ -50,7 +50,7 @@ export const getReactorDefaultDrivesConfig = (): Pick<
             removeOldRemoteDrives:
                 defaultDrivesUrl.length > 0
                     ? {
-                          strategy: 'preserve-by-url',
+                          strategy: 'preserve-by-url-and-detach',
                           urls: defaultDrivesUrl,
                       }
                     : { strategy: 'preserve-all' },


### PR DESCRIPTION
## Description:

- Change `removeOldRemoteDrives` strategy to `preserve-by-url-and-detach`

> NOTE: This PR requires https://github.com/powerhouse-inc/document-drive/pull/305


![demo](https://github.com/user-attachments/assets/c42ce170-ece9-4e2b-a7fc-3b6d52a00b4e)
