### PR TITLE
fix: use single instance of react dependencies on studio mode

### DIFF
--- a/studio/index.ts
+++ b/studio/index.ts
@@ -66,13 +66,18 @@ export async function startServer() {
             open: true,
         },
         plugins: [
-            viteConnectDevStudioPlugin(),
+            viteConnectDevStudioPlugin(true),
             viteEnvs({
                 declarationFile: join(studioDirname, '../.env'),
                 computedEnv: studioConfig,
             }),
             runShellScriptPlugin(viteEnvsScript),
         ],
+        build: {
+            rollupOptions: {
+                input: 'index.html',
+            },
+        },
     };
 
     const server = await createServer(config);

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -9,7 +9,7 @@ import { createHtmlPlugin } from 'vite-plugin-html';
 import svgr from 'vite-plugin-svgr';
 import clientConfig from './client.config';
 import pkg from './package.json';
-import { viteConnectDevStudioPlugin } from './studio/vite-plugin';
+import { externalIds, viteConnectDevStudioPlugin } from './studio/vite-plugin';
 
 export default defineConfig(({ mode }) => {
     const isProd = mode === 'production';
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => {
     const uploadSentrySourcemaps = authToken && org && project;
 
     const plugins: PluginOption[] = [
-        viteConnectDevStudioPlugin(env),
+        viteConnectDevStudioPlugin(false, env),
         react({
             include: 'src/**/*.tsx',
             babel: {
@@ -106,14 +106,7 @@ export default defineConfig(({ mode }) => {
                             ? `${chunk.name}.js`
                             : 'assets/[name].[hash].js',
                 },
-                external: [
-                    'node:crypto',
-                    'react',
-                    'react/jsx-runtime',
-                    'react/jsx-dev-runtime',
-                    'react-dom',
-                    'react-dom/client',
-                ],
+                external: ['node:crypto', externalIds],
             },
         },
         resolve: {


### PR DESCRIPTION
When building Connect, `rollupOptions.external` is used to prevent react imports to be resolved by vite.

Studio uses Vite Dev Server which is very aggressive at pre-bundling dependencies and uses `esbuild` instead of `rollup`.

It changes all `import from "react"` into `import from "/@id/react"`. Since vite doesn't provide a method to do this on the dev server, this uses a proposed plugin to revert that import change.

https://github.com/vitejs/vite/issues/6393#issuecomment-1006819717
