### PR TITLE
feat: force usage of env variables when vite-envs.sh execution fails

### DIFF
--- a/studio/helpers.ts
+++ b/studio/helpers.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const studioDirname = fileURLToPath(new URL('.', import.meta.url));
+const appPath = join(studioDirname, '..');
+
+export function backupIndexHtml(restore = false) {
+    console.log('Creating backup of index.html -- restore:', restore);
+    const filePath = join(appPath, 'index.html');
+    const backupPath = join(appPath, 'index.html.bak');
+
+    const paths = restore ? [backupPath, filePath] : [filePath, backupPath];
+
+    if (fs.existsSync(paths[0])) {
+        fs.copyFileSync(paths[0], paths[1]);
+    }
+}
+
+export function removeBase64EnvValues() {
+    backupIndexHtml();
+    console.log('Removing Base64 values from index.html');
+
+    const filePath = join(appPath, 'index.html');
+
+    // Read the HTML file
+    fs.readFile(filePath, 'utf-8', (err, data) => {
+        if (err) {
+            console.error('Error reading file:', err);
+            return;
+        }
+
+        // Use regex to replace the dynamic Base64 values with empty strings
+        const modifiedData = data
+            .replace(
+                /"LOCAL_DOCUMENT_MODELS":\s*".*?",/,
+                `"LOCAL_DOCUMENT_MODELS": "",`,
+            )
+            .replace(
+                /"LOCAL_DOCUMENT_EDITORS":\s*".*?"/,
+                `"LOCAL_DOCUMENT_EDITORS": ""`,
+            );
+
+        // Write the modified content back to the file
+        fs.writeFile(filePath, modifiedData, 'utf-8', err => {
+            if (err) {
+                console.error('Error writing file:', err);
+                return;
+            }
+            console.log('File updated successfully!');
+        });
+    });
+}

--- a/studio/server.ts
+++ b/studio/server.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createLogger, createServer, InlineConfig, Plugin } from 'vite';
 import { viteEnvs } from 'vite-envs';
+import { backupIndexHtml, removeBase64EnvValues } from './helpers';
 import { getStudioConfig, viteConnectDevStudioPlugin } from './vite-plugin';
 
 const studioDirname = fileURLToPath(new URL('.', import.meta.url));
@@ -37,6 +38,7 @@ function runShellScriptPlugin(scriptPath: string): Plugin {
                         console.error(
                             `Error executing the script: ${error.message}`,
                         );
+                        removeBase64EnvValues();
                         return;
                     }
                     if (stderr) {
@@ -49,6 +51,7 @@ function runShellScriptPlugin(scriptPath: string): Plugin {
 }
 
 export async function startServer() {
+    backupIndexHtml(true);
     const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3000;
     const studioConfig = getStudioConfig();
 


### PR DESCRIPTION
## Description:

MacOS and Linux: No changes

in Windows:
if running connect from git bash or something similar, the app follows the normal flow (runs vite-envs.sh to define the env variables)

if running in PowerShell or something similar, the flow is executed as follow (before start the dev server):
- creates a backup of the `index.html`
- updates the `index.html` by removing default base64 values for LOCAL_DOCUMENT_MODELS and LOCAL_DOCUMENT_EDITORS in `envWithValuesInBase64` object (this forces the devServer to take the values from process.env)
- starts the dev server

the backup file is restored before running the vite-envs.sh, this allows windows users to change between powershell and bash compatible command lines

![2024-10-30 16 08 58](https://github.com/user-attachments/assets/7abf2551-21c1-4680-bf75-3237992247d5)
