### PR TITLE
fix(connect): removed duplicated editor check

### DIFF
--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -98,7 +98,9 @@ export function DocumentEditor(props: EditorProps) {
         editor === undefined ||
         (!!document &&
             editor &&
-            !editor.documentTypes.includes(document.documentType));
+            !editor.documentTypes.includes(document.documentType) &&
+            !editor.documentTypes.includes('*'));
+
     const canUndo =
         !!document &&
         (document.revision.global > 0 || document.revision.local > 0);


### PR DESCRIPTION
## Description:

- Since we are using `getEditor` to match a valid editor for the document type, there's no need to do this check again. This was keeping the `isLoadingEditor = true` for the json editor (because this second check doesn't match '*' with the document type)

<img width="1728" alt="Screenshot 2024-11-06 at 11 49 27 AM" src="https://github.com/user-attachments/assets/674b0e48-858d-4852-b005-b77ffba52311">
 